### PR TITLE
[feat] 공지 기능 api 구현 

### DIFF
--- a/src/main/java/com/umc/hwaroak/controller/NoticeController.java
+++ b/src/main/java/com/umc/hwaroak/controller/NoticeController.java
@@ -1,0 +1,35 @@
+package com.umc.hwaroak.controller;
+
+import com.umc.hwaroak.dto.NoticeResponseDto;
+import com.umc.hwaroak.service.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Notice", description = "공지 관련 API")
+@RestController
+@RequestMapping("/notices")
+@RequiredArgsConstructor
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @Operation(summary = "공지 목록 조회", description = "최신순으로 공지 제목 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "공지 목록 조회 성공")
+    @GetMapping
+    public List<NoticeResponseDto.PreviewDto> getNoticeList() {
+        return noticeService.getNoticeList();
+    }
+
+    @Operation(summary = "공지 상세 조회", description = "공지 ID를 통해 상세 내용을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "공지 상세 조회 성공")
+    @ApiResponse(responseCode = "4041", description = "공지 없음 (NOTICE_NOT_FOUND)")
+    @GetMapping("/{id}")
+    public NoticeResponseDto.InfoDto getNoticeDetail(@PathVariable Long id) {
+        return noticeService.getNoticeDetail(id);
+    }
+}

--- a/src/main/java/com/umc/hwaroak/domain/Notice.java
+++ b/src/main/java/com/umc/hwaroak/domain/Notice.java
@@ -2,8 +2,10 @@ package com.umc.hwaroak.domain;
 
 import com.umc.hwaroak.domain.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 @Table(name = "notice")
 public class Notice extends BaseEntity {
 

--- a/src/main/java/com/umc/hwaroak/domain/Notice.java
+++ b/src/main/java/com/umc/hwaroak/domain/Notice.java
@@ -1,0 +1,20 @@
+package com.umc.hwaroak.domain;
+
+import com.umc.hwaroak.domain.common.BaseEntity;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "notice")
+public class Notice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notice_id")
+    private Long id;
+
+    @Column(name = "title", length = 256, nullable = false)
+    private String title;
+
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    private String content;
+}

--- a/src/main/java/com/umc/hwaroak/dto/NoticeResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/NoticeResponseDto.java
@@ -1,5 +1,6 @@
 package com.umc.hwaroak.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 
 public class NoticeResponseDto {
+
     /**
      * 최신순 정렬용 Dto
      */
@@ -16,22 +18,36 @@ public class NoticeResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class PreviewDto {
+
+        @Schema(description = "공지 ID", example = "1")
         private Long id;
+
+        @Schema(description = "공지 제목", example = "서버 점검 안내")
         private String title;
+
+        @Schema(description = "공지 생성일", example = "2025-07-14")
         private LocalDate createdAt; // 프론트에서 언제 올라온 공지인지 정렬 및 표시용
     }
 
     /**
-     *  공지 상세보기용 Dto
+     * 공지 상세보기용 Dto
      */
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class InfoDto {
+
+        @Schema(description = "공지 ID", example = "1")
         private Long id;
+
+        @Schema(description = "공지 제목", example = "서버 점검 안내")
         private String title;
+
+        @Schema(description = "공지 내용", example = "7월 16일 03시부터 서버 점검이 진행됩니다.")
         private String content;
+
+        @Schema(description = "공지 생성일", example = "2025-07-14")
         private LocalDate createdAt;
     }
 }

--- a/src/main/java/com/umc/hwaroak/dto/NoticeResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/NoticeResponseDto.java
@@ -1,0 +1,37 @@
+package com.umc.hwaroak.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class NoticeResponseDto {
+    /**
+     * 최신순 정렬용 Dto
+     */
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PreviewDto {
+        private Long id;
+        private String title;
+        private LocalDateTime createdAt; // 프론트에서 언제 올라온 공지인지 정렬 및 표시용
+    }
+
+    /**
+     *  공지 상세보기용 Dto
+     */
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InfoDto {
+        private Long id;
+        private String title;
+        private String content;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/umc/hwaroak/dto/NoticeResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/NoticeResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public class NoticeResponseDto {
     /**
@@ -18,7 +18,7 @@ public class NoticeResponseDto {
     public static class PreviewDto {
         private Long id;
         private String title;
-        private LocalDateTime createdAt; // 프론트에서 언제 올라온 공지인지 정렬 및 표시용
+        private LocalDate createdAt; // 프론트에서 언제 올라온 공지인지 정렬 및 표시용
     }
 
     /**
@@ -32,6 +32,6 @@ public class NoticeResponseDto {
         private Long id;
         private String title;
         private String content;
-        private LocalDateTime createdAt;
+        private LocalDate createdAt;
     }
 }

--- a/src/main/java/com/umc/hwaroak/repository/NoticeRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package com.umc.hwaroak.repository;
+
+import com.umc.hwaroak.domain.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+}

--- a/src/main/java/com/umc/hwaroak/repository/NoticeRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/NoticeRepository.java
@@ -3,5 +3,9 @@ package com.umc.hwaroak.repository;
 import com.umc.hwaroak.domain.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    List<Notice> findAllByOrderByCreatedAtDesc();
+
 }

--- a/src/main/java/com/umc/hwaroak/response/ErrorCode.java
+++ b/src/main/java/com/umc/hwaroak/response/ErrorCode.java
@@ -11,6 +11,9 @@ public enum ErrorCode implements BaseCode{
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "메소드 요청이 잘못됐습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "접근 권한이 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SE5001", "서버 내의 오류입니다."),
+
+    // Notice 관련
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NO4041", "해당 공지를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/umc/hwaroak/service/NoticeService.java
+++ b/src/main/java/com/umc/hwaroak/service/NoticeService.java
@@ -1,0 +1,12 @@
+package com.umc.hwaroak.service;
+
+import com.umc.hwaroak.dto.NoticeResponseDto;
+
+import java.util.List;
+
+public interface NoticeService {
+
+    List<NoticeResponseDto.PreviewDto> getNoticeList();
+
+    NoticeResponseDto.InfoDto getNoticeDetail(Long id);
+}

--- a/src/main/java/com/umc/hwaroak/service/NoticeServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/NoticeServiceImpl.java
@@ -1,0 +1,44 @@
+package com.umc.hwaroak.service;
+
+import com.umc.hwaroak.domain.Notice;
+import com.umc.hwaroak.dto.NoticeResponseDto;
+import com.umc.hwaroak.exception.GeneralException;
+import com.umc.hwaroak.repository.NoticeRepository;
+import com.umc.hwaroak.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeServiceImpl implements NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    @Override
+    public List<NoticeResponseDto.PreviewDto> getNoticeList() {
+        return noticeRepository.findAllByOrderByCreatedAtDesc().stream()
+                .map(notice -> NoticeResponseDto.PreviewDto.builder()
+                        .id(notice.getId())
+                        .title(notice.getTitle())
+                        .createdAt(notice.getCreatedAt())
+                        .build())
+                .collect(toList());
+    }
+
+    @Override
+    public NoticeResponseDto.InfoDto getNoticeDetail(Long id) {
+        Notice notice = noticeRepository.findById(id)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOTICE_NOT_FOUND));
+
+        return NoticeResponseDto.InfoDto.builder()
+                .id(notice.getId())
+                .title(notice.getTitle())
+                .content(notice.getContent())
+                .createdAt(notice.getCreatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
- Closes #12 

---
## ✨ Summary (작업 개요)
- 공지 최신순으로 조회하는 api
- 공지 상세보기 api 

---
## 🛠 Work Description (작업 상세)

service 패키지 만들고 진행했습니다!
Notice 관련 Entity, Repository, Service, ResponseDto, Controller 흐름으로 생성 후 진행하였습니다.

---
## ⚠️ Trouble Shooting (문제 해결)

---
## 🧪 Test Coverage
더미데이터 넣고, 최신순 정렬해서 가져오기 확인했습니다. 
<img width="2906" height="1354" alt="image" src="https://github.com/user-attachments/assets/2eed5cc3-bcf0-4e1d-9490-f3b94c4776a3" />

id로 조회한 공지 상세보기 확인했습니다.
<img width="2844" height="792" alt="image" src="https://github.com/user-attachments/assets/1bdecfb8-a201-44b7-8ddc-d15df2d509de" />

없는 숫자 넣어서 오류 확인했습니다.
<img width="2910" height="1568" alt="image" src="https://github.com/user-attachments/assets/5fc7da4e-b3b5-48d9-834c-7ecdd321b9e3" />


---
## 😅 Uncompleted Tasks (미완료 작업)

---
## 📢 To Reviewers
ControllerAdvice가 응답형식 감싸주니까 Controller 깨끗해져서 너무 좋네요!!

---
