### PR TITLE
[feat] 친구 기능 api 구현

### DIFF
--- a/src/main/java/com/umc/hwaroak/HwaroakApplication.java
+++ b/src/main/java/com/umc/hwaroak/HwaroakApplication.java
@@ -2,8 +2,10 @@ package com.umc.hwaroak;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class HwaroakApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/umc/hwaroak/controller/AlarmController.java
+++ b/src/main/java/com/umc/hwaroak/controller/AlarmController.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Tag(name = "Alarm", description = "알림 관련 API")
 @RestController
-@RequestMapping("/alarms")
+@RequestMapping("/api/v1/alarms")
 @RequiredArgsConstructor
 public class AlarmController {
 

--- a/src/main/java/com/umc/hwaroak/controller/FriendController.java
+++ b/src/main/java/com/umc/hwaroak/controller/FriendController.java
@@ -51,4 +51,11 @@ public class FriendController {
     public List<FriendResponseDto.FriendInfo> getFriendList() {
         return friendService.getFriendList();
     }
+
+    @Operation(summary = "받은 친구 요청 목록 조회", description = "아직 수락/거절되지 않은, 내가 받은 친구 요청 목록을 최신순으로 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "받은 친구 요청 목록 조회 성공")
+    @GetMapping("/received")
+    public List<FriendResponseDto.ReceivedRequestInfo> getReceivedFriendRequests() {
+        return friendService.getReceivedFriendRequests();
+    }
 }

--- a/src/main/java/com/umc/hwaroak/controller/FriendController.java
+++ b/src/main/java/com/umc/hwaroak/controller/FriendController.java
@@ -21,6 +21,7 @@ public class FriendController {
 
     @Operation(summary = "친구 요청 보내기", description = "상대방에게 친구 요청을 보냅니다.")
     @ApiResponse(responseCode = "200", description = "친구 요청 성공")
+    @ApiResponse(responseCode = "400", description = "존재하지 않는 사용자 (MEMBER_NOT_FOUND) 또는 자기 자신에게 요청 (CANNOT_ADD_SELF) 또는 중복 요청 (FRIEND_ALREADY_EXISTS_OR_REQUESTED)")
     @PostMapping("/request")
     public void requestFriend(@RequestBody FriendRequestDto.Request requestDto) {
         friendService.requestFriend(requestDto.getReceiverId());
@@ -28,6 +29,8 @@ public class FriendController {
 
     @Operation(summary = "친구 요청 수락", description = "상대방이 보낸 친구 요청을 수락합니다.")
     @ApiResponse(responseCode = "200", description = "친구 요청 수락 성공")
+    @ApiResponse(responseCode = "400", description = "이미 처리된 요청 (FRIEND_REQUEST_NOT_PENDING)")
+    @ApiResponse(responseCode = "404", description = "요청 보낸 사용자 없음 (MEMBER_NOT_FOUND) 또는 친구 요청 없음 (FRIEND_REQUEST_NOT_FOUND)")
     @PostMapping("/accept")
     public void acceptFriendRequest(@RequestBody FriendRequestDto.Accept requestDto) {
         friendService.acceptFriendRequest(requestDto.getSenderId());
@@ -35,6 +38,8 @@ public class FriendController {
 
     @Operation(summary = "친구 요청 거절", description = "상대방이 보낸 친구 요청을 거절합니다.")
     @ApiResponse(responseCode = "200", description = "친구 요청 거절 성공")
+    @ApiResponse(responseCode = "400", description = "이미 처리된 요청 (FRIEND_REQUEST_NOT_PENDING)")
+    @ApiResponse(responseCode = "404", description = "요청 보낸 사용자 없음 (MEMBER_NOT_FOUND) 또는 친구 요청 없음 (FRIEND_REQUEST_NOT_FOUND)")
     @PostMapping("/reject")
     public void rejectFriendRequest(@RequestBody FriendRequestDto.Reject requestDto) {
         friendService.rejectFriendRequest(requestDto.getSenderId());
@@ -46,5 +51,4 @@ public class FriendController {
     public List<FriendResponseDto.FriendInfo> getFriendList() {
         return friendService.getFriendList();
     }
-
 }

--- a/src/main/java/com/umc/hwaroak/controller/FriendController.java
+++ b/src/main/java/com/umc/hwaroak/controller/FriendController.java
@@ -29,4 +29,12 @@ public class FriendController {
     public void acceptFriendRequest(@RequestBody FriendRequestDto.Accept requestDto) {
         friendService.acceptFriendRequest(requestDto.getSenderId());
     }
+
+    @Operation(summary = "친구 요청 거절", description = "상대방이 보낸 친구 요청을 거절합니다.")
+    @ApiResponse(responseCode = "200", description = "친구 요청 거절 성공")
+    @PostMapping("/reject")
+    public void rejectFriendRequest(@RequestBody FriendRequestDto.Reject requestDto) {
+        friendService.rejectFriendRequest(requestDto.getSenderId());
+    }
+
 }

--- a/src/main/java/com/umc/hwaroak/controller/FriendController.java
+++ b/src/main/java/com/umc/hwaroak/controller/FriendController.java
@@ -1,12 +1,15 @@
 package com.umc.hwaroak.controller;
 
 import com.umc.hwaroak.dto.FriendRequestDto;
+import com.umc.hwaroak.dto.FriendResponseDto;
 import com.umc.hwaroak.service.FriendService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Friend", description = "친구 기능 관련 API")
 @RestController
@@ -35,6 +38,13 @@ public class FriendController {
     @PostMapping("/reject")
     public void rejectFriendRequest(@RequestBody FriendRequestDto.Reject requestDto) {
         friendService.rejectFriendRequest(requestDto.getSenderId());
+    }
+
+    @Operation(summary = "친구 목록 조회", description = "현재 로그인한 유저의 친구 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "친구 목록 조회 성공")
+    @GetMapping
+    public List<FriendResponseDto.FriendInfo> getFriendList() {
+        return friendService.getFriendList();
     }
 
 }

--- a/src/main/java/com/umc/hwaroak/controller/FriendController.java
+++ b/src/main/java/com/umc/hwaroak/controller/FriendController.java
@@ -58,4 +58,14 @@ public class FriendController {
     public List<FriendResponseDto.ReceivedRequestInfo> getReceivedFriendRequests() {
         return friendService.getReceivedFriendRequests();
     }
+
+    @Operation(summary = "친구 삭제", description = "현재 친구인 사용자를 친구 목록에서 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "친구 삭제 성공")
+    @ApiResponse(responseCode = "404", description = "친구 관계가 존재하지 않음 (FRIEND_NOT_FOUND)")
+    @DeleteMapping
+    public void deleteFriend(@RequestBody FriendRequestDto.Delete requestDto) {
+        friendService.deleteFriend(requestDto.getMemberId());
+    }
+
+
 }

--- a/src/main/java/com/umc/hwaroak/controller/FriendController.java
+++ b/src/main/java/com/umc/hwaroak/controller/FriendController.java
@@ -1,0 +1,25 @@
+package com.umc.hwaroak.controller;
+
+import com.umc.hwaroak.dto.FriendRequestDto;
+import com.umc.hwaroak.service.FriendService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Friend", description = "친구 기능 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/friends")
+public class FriendController {
+
+    private final FriendService friendService;
+
+    @Operation(summary = "친구 요청 보내기", description = "상대방에게 친구 요청을 보냅니다.")
+    @ApiResponse(responseCode = "200", description = "친구 요청 성공")
+    @PostMapping("/request")
+    public void requestFriend(@RequestBody FriendRequestDto.Request requestDto) {
+        friendService.requestFriend(requestDto.getReceiverId());
+    }
+}

--- a/src/main/java/com/umc/hwaroak/controller/FriendController.java
+++ b/src/main/java/com/umc/hwaroak/controller/FriendController.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Tag(name = "Friend", description = "친구 기능 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/friends")
+@RequestMapping("/api/v1/friends")
 public class FriendController {
 
     private final FriendService friendService;

--- a/src/main/java/com/umc/hwaroak/controller/FriendController.java
+++ b/src/main/java/com/umc/hwaroak/controller/FriendController.java
@@ -22,4 +22,11 @@ public class FriendController {
     public void requestFriend(@RequestBody FriendRequestDto.Request requestDto) {
         friendService.requestFriend(requestDto.getReceiverId());
     }
+
+    @Operation(summary = "친구 요청 수락", description = "상대방이 보낸 친구 요청을 수락합니다.")
+    @ApiResponse(responseCode = "200", description = "친구 요청 수락 성공")
+    @PostMapping("/accept")
+    public void acceptFriendRequest(@RequestBody FriendRequestDto.Accept requestDto) {
+        friendService.acceptFriendRequest(requestDto.getSenderId());
+    }
 }

--- a/src/main/java/com/umc/hwaroak/controller/FriendController.java
+++ b/src/main/java/com/umc/hwaroak/controller/FriendController.java
@@ -31,18 +31,18 @@ public class FriendController {
     @ApiResponse(responseCode = "200", description = "친구 요청 수락 성공")
     @ApiResponse(responseCode = "400", description = "이미 처리된 요청 (FRIEND_REQUEST_NOT_PENDING)")
     @ApiResponse(responseCode = "404", description = "요청 보낸 사용자 없음 (MEMBER_NOT_FOUND) 또는 친구 요청 없음 (FRIEND_REQUEST_NOT_FOUND)")
-    @PostMapping("/accept")
-    public void acceptFriendRequest(@RequestBody FriendRequestDto.Accept requestDto) {
-        friendService.acceptFriendRequest(requestDto.getSenderId());
+    @PostMapping("/{friendId}/accept")
+    public void acceptFriendRequest(@PathVariable Long friendId) {
+        friendService.acceptFriendRequest(friendId);
     }
 
     @Operation(summary = "친구 요청 거절", description = "상대방이 보낸 친구 요청을 거절합니다.")
     @ApiResponse(responseCode = "200", description = "친구 요청 거절 성공")
     @ApiResponse(responseCode = "400", description = "이미 처리된 요청 (FRIEND_REQUEST_NOT_PENDING)")
     @ApiResponse(responseCode = "404", description = "요청 보낸 사용자 없음 (MEMBER_NOT_FOUND) 또는 친구 요청 없음 (FRIEND_REQUEST_NOT_FOUND)")
-    @PostMapping("/reject")
-    public void rejectFriendRequest(@RequestBody FriendRequestDto.Reject requestDto) {
-        friendService.rejectFriendRequest(requestDto.getSenderId());
+    @PostMapping("/{friendId}/reject")
+    public void rejectFriendRequest(@PathVariable Long friendId) {
+        friendService.rejectFriendRequest(friendId);
     }
 
     @Operation(summary = "친구 목록 조회", description = "현재 로그인한 유저의 친구 목록을 조회합니다.")
@@ -62,9 +62,9 @@ public class FriendController {
     @Operation(summary = "친구 삭제", description = "현재 친구인 사용자를 친구 목록에서 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "친구 삭제 성공")
     @ApiResponse(responseCode = "404", description = "친구 관계가 존재하지 않음 (FRIEND_NOT_FOUND)")
-    @DeleteMapping
-    public void deleteFriend(@RequestBody FriendRequestDto.Delete requestDto) {
-        friendService.deleteFriend(requestDto.getMemberId());
+    @DeleteMapping("/{friendId}")
+    public void deleteFriend(@PathVariable Long friendId) {
+        friendService.deleteFriend(friendId);
     }
 
 

--- a/src/main/java/com/umc/hwaroak/domain/Friend.java
+++ b/src/main/java/com/umc/hwaroak/domain/Friend.java
@@ -3,9 +3,14 @@ package com.umc.hwaroak.domain;
 import com.umc.hwaroak.domain.common.BaseEntity;
 import com.umc.hwaroak.domain.common.FriendStatus;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "friend")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 기본 생성자
 public class Friend extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,4 +28,11 @@ public class Friend extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "friend_status")
     private FriendStatus status;
+
+    // 친구 요청 생성 시 사용하는 생성자
+    public Friend(Member sender, Member receiver, FriendStatus status) {
+        this.sender = sender;
+        this.receiver = receiver;
+        this.status = status;
+    }
 }

--- a/src/main/java/com/umc/hwaroak/domain/Friend.java
+++ b/src/main/java/com/umc/hwaroak/domain/Friend.java
@@ -35,4 +35,9 @@ public class Friend extends BaseEntity {
         this.receiver = receiver;
         this.status = status;
     }
+
+    // 상태 변경 로직
+    public void updateStatus(FriendStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/umc/hwaroak/domain/common/FriendStatus.java
+++ b/src/main/java/com/umc/hwaroak/domain/common/FriendStatus.java
@@ -2,6 +2,7 @@ package com.umc.hwaroak.domain.common;
 
 public enum FriendStatus {
     ACCEPTED,
+    REQUESTED,
     REJECTED,
     BLOCKED
 }

--- a/src/main/java/com/umc/hwaroak/domain/common/FriendStatus.java
+++ b/src/main/java/com/umc/hwaroak/domain/common/FriendStatus.java
@@ -4,5 +4,5 @@ public enum FriendStatus {
     ACCEPTED,
     REQUESTED,
     REJECTED,
-    BLOCKED
+    BLOCKED // soft delete
 }

--- a/src/main/java/com/umc/hwaroak/dto/FriendRequestDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/FriendRequestDto.java
@@ -27,4 +27,11 @@ public class FriendRequestDto {
         @Schema(description = "친구 요청을 보낸 사람의 member ID", example = "1")
         private Long senderId;
     }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Delete {
+        @Schema(description = "삭제할 친구의 member ID", example = "3")
+        private Long memberId;
+    }
 }

--- a/src/main/java/com/umc/hwaroak/dto/FriendRequestDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/FriendRequestDto.java
@@ -20,4 +20,11 @@ public class FriendRequestDto {
         @Schema(description = "요청을 보낸 친구의 member ID", example = "1")
         private Long senderId;
     }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Reject {
+        @Schema(description = "친구 요청을 보낸 사람의 member ID", example = "1")
+        private Long senderId;
+    }
 }

--- a/src/main/java/com/umc/hwaroak/dto/FriendRequestDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/FriendRequestDto.java
@@ -1,0 +1,16 @@
+package com.umc.hwaroak.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class FriendRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class Request {
+
+        @Schema(description = "요청받을 친구의 member ID", example = "2")
+        private Long receiverId;
+    }
+}

--- a/src/main/java/com/umc/hwaroak/dto/FriendRequestDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/FriendRequestDto.java
@@ -13,4 +13,11 @@ public class FriendRequestDto {
         @Schema(description = "요청받을 친구의 member ID", example = "2")
         private Long receiverId;
     }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Accept {
+        @Schema(description = "요청을 보낸 친구의 member ID", example = "1")
+        private Long senderId;
+    }
 }

--- a/src/main/java/com/umc/hwaroak/dto/FriendResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/FriendResponseDto.java
@@ -24,4 +24,19 @@ public class FriendResponseDto {
         @Schema(description = "친구 한줄소개", example = "오늘도 잘 부탁해요~")
         private String introduction;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ReceivedRequestInfo {
+
+        @Schema(description = "요청 보낸 사용자 ID", example = "3")
+        private Long memberId;
+
+        @Schema(description = "요청 보낸 사용자 닉네임", example = "감자소년")
+        private String nickname;
+
+        @Schema(description = "요청 보낸 사용자의 자기소개", example = "함께 친구해요 :)")
+        private String introduction;
+    }
 }

--- a/src/main/java/com/umc/hwaroak/dto/FriendResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/FriendResponseDto.java
@@ -1,0 +1,27 @@
+package com.umc.hwaroak.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class FriendResponseDto {
+
+    /**
+     * 친구 목록 조회 시 사용하는 친구 정보 DTO
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class FriendInfo {
+
+        @Schema(description = "친구의 member ID", example = "5")
+        private Long memberId;
+
+        @Schema(description = "친구 닉네임", example = "햇살가득이")
+        private String nickname;
+
+        @Schema(description = "친구 한줄소개", example = "오늘도 잘 부탁해요~")
+        private String introduction;
+    }
+}

--- a/src/main/java/com/umc/hwaroak/repository/FriendRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/FriendRepository.java
@@ -41,4 +41,10 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
      * @return 나와 친구인 Friend 리스트
      */
     List<Friend> findAllBySenderOrReceiverAndStatus(Member sender, Member receiver, FriendStatus status);
+
+    /**
+     * 받은 친구 요청 목록을 최신순(createdAt DESC)으로 조회
+     * 조건: receiver = 현재 유저, status = REQUESTED
+     */
+    List<Friend> findAllByReceiverAndStatusOrderByCreatedAtDesc(Member receiver, FriendStatus status);
 }

--- a/src/main/java/com/umc/hwaroak/repository/FriendRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/FriendRepository.java
@@ -1,0 +1,18 @@
+package com.umc.hwaroak.repository;
+
+import com.umc.hwaroak.domain.Friend;
+import com.umc.hwaroak.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+
+    /**
+     * sender → receiver 관계가 이미 존재하는지 확인합니다.
+     * 요청 중복, 친구 중복 여부 확인 시 사용됩니다.
+     *
+     * @param sender 요청을 보낸 유저
+     * @param receiver 요청을 받은 유저
+     * @return 해당 쌍의 Friend 관계가 존재하면 true
+     */
+    boolean existsBySenderAndReceiver(Member sender, Member receiver);
+}

--- a/src/main/java/com/umc/hwaroak/repository/FriendRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/FriendRepository.java
@@ -4,6 +4,8 @@ import com.umc.hwaroak.domain.Friend;
 import com.umc.hwaroak.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     /**
@@ -15,4 +17,14 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
      * @return 해당 쌍의 Friend 관계가 존재하면 true
      */
     boolean existsBySenderAndReceiver(Member sender, Member receiver);
+
+    /**
+     * sender → receiver 방향의 친구 요청을 조회
+     * - 수락/거절 시 요청을 식별하기 위한 메서드
+     *
+     * @param sender 요청 보낸 사람
+     * @param receiver 요청 받은 사람 (로그인 유저)
+     * @return Friend 엔티티 (없으면 Optional.empty)
+     */
+    Optional<Friend> findBySenderAndReceiver(Member sender, Member receiver);
 }

--- a/src/main/java/com/umc/hwaroak/repository/FriendRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/FriendRepository.java
@@ -4,6 +4,8 @@ import com.umc.hwaroak.domain.Friend;
 import com.umc.hwaroak.domain.Member;
 import com.umc.hwaroak.domain.common.FriendStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,16 +33,18 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     Optional<Friend> findBySenderAndReceiver(Member sender, Member receiver);
 
     /**
-     * 친구 목록 조회용
-     * 현재 로그인한 유저가 sender 또는 receiver 이고,
-     * 친구 상태가 ACCEPTED 인 모든 Friend 관계를 가져온다.
+     * 친구 목록 조회 (정확한 ACCEPTED 상태만)
+     * - 로그인한 사용자가 sender 또는 receiver인 친구 관계 중
+     * - 상태가 정확히 FriendStatus.ACCEPTED 인 것만 반환
+     * - status 조건이 OR 조건과 충돌하지 않도록 JPQL로 명시
      *
-     * @param sender 나
-     * @param receiver 나
-     * @param status 친구 상태 (ACCEPTED)
-     * @return 나와 친구인 Friend 리스트
+     * @param member 현재 로그인한 사용자
+     * @return 친구 관계 리스트 (ACCEPTED 상태만)
      */
-    List<Friend> findAllBySenderOrReceiverAndStatus(Member sender, Member receiver, FriendStatus status);
+    @Query("SELECT f FROM Friend f " +
+            "WHERE (f.sender = :member OR f.receiver = :member) " +
+            "AND f.status = com.umc.hwaroak.domain.common.FriendStatus.ACCEPTED")
+    List<Friend> findAllAcceptedFriends(@Param("member") Member member);
 
     /**
      * 받은 친구 요청 목록을 최신순(createdAt DESC)으로 조회

--- a/src/main/java/com/umc/hwaroak/repository/FriendRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/FriendRepository.java
@@ -47,4 +47,15 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
      * 조건: receiver = 현재 유저, status = REQUESTED
      */
     List<Friend> findAllByReceiverAndStatusOrderByCreatedAtDesc(Member receiver, FriendStatus status);
+
+    /**
+     * 특정 상태(FriendStatus)를 가진 친구 관계를 조회
+     * 예: 친구 삭제 시 ACCEPTED 상태인 관계 찾기
+     *
+     * @param sender 나 or 상대방
+     * @param receiver 상대방 or 나
+     * @param status 친구 상태
+     * @return Friend 관계 (Optional)
+     */
+    Optional<Friend> findBySenderAndReceiverAndStatus(Member sender, Member receiver, FriendStatus status);
 }

--- a/src/main/java/com/umc/hwaroak/repository/FriendRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/FriendRepository.java
@@ -2,8 +2,10 @@ package com.umc.hwaroak.repository;
 
 import com.umc.hwaroak.domain.Friend;
 import com.umc.hwaroak.domain.Member;
+import com.umc.hwaroak.domain.common.FriendStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
@@ -27,4 +29,16 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
      * @return Friend 엔티티 (없으면 Optional.empty)
      */
     Optional<Friend> findBySenderAndReceiver(Member sender, Member receiver);
+
+    /**
+     * 친구 목록 조회용
+     * 현재 로그인한 유저가 sender 또는 receiver 이고,
+     * 친구 상태가 ACCEPTED 인 모든 Friend 관계를 가져온다.
+     *
+     * @param sender 나
+     * @param receiver 나
+     * @param status 친구 상태 (ACCEPTED)
+     * @return 나와 친구인 Friend 리스트
+     */
+    List<Friend> findAllBySenderOrReceiverAndStatus(Member sender, Member receiver, FriendStatus status);
 }

--- a/src/main/java/com/umc/hwaroak/response/ErrorCode.java
+++ b/src/main/java/com/umc/hwaroak/response/ErrorCode.java
@@ -25,6 +25,9 @@ public enum ErrorCode implements BaseCode{
     FRIEND_REQUEST_NOT_PENDING(HttpStatus.BAD_REQUEST, "FRIEND4002", "이미 처리된 친구 요청입니다."),
     CANNOT_ADD_SELF(HttpStatus.BAD_REQUEST, "FRIEND4003", "자기 자신에게는 친구 요청을 보낼 수 없습니다."),
     FRIEND_ALREADY_EXISTS_OR_REQUESTED(HttpStatus.BAD_REQUEST, "FRIEND4004", "이미 친구이거나 요청을 보낸 상태입니다."),
+    FRIEND_CANNOT_BE_DELETED(HttpStatus.BAD_REQUEST, "FRIEND4005", "해당 친구 상태에서는 삭제할 수 없습니다."),
+    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND4042", "해당 친구 관계를 찾을 수 없습니다."),
+
 
     ;
 

--- a/src/main/java/com/umc/hwaroak/response/ErrorCode.java
+++ b/src/main/java/com/umc/hwaroak/response/ErrorCode.java
@@ -19,6 +19,11 @@ public enum ErrorCode implements BaseCode{
     //Member
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
 
+
+    // Friend
+    CANNOT_ADD_SELF(HttpStatus.BAD_REQUEST, "FRIEND4001", "자기 자신에게는 친구 요청을 보낼 수 없습니다."),
+    FRIEND_ALREADY_EXISTS_OR_REQUESTED(HttpStatus.BAD_REQUEST, "FRIEND4002", "이미 친구이거나 요청을 보낸 상태입니다."),
+
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/umc/hwaroak/response/ErrorCode.java
+++ b/src/main/java/com/umc/hwaroak/response/ErrorCode.java
@@ -21,8 +21,10 @@ public enum ErrorCode implements BaseCode{
 
 
     // Friend
-    CANNOT_ADD_SELF(HttpStatus.BAD_REQUEST, "FRIEND4001", "자기 자신에게는 친구 요청을 보낼 수 없습니다."),
-    FRIEND_ALREADY_EXISTS_OR_REQUESTED(HttpStatus.BAD_REQUEST, "FRIEND4002", "이미 친구이거나 요청을 보낸 상태입니다."),
+    FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND4041", "해당 친구 요청을 찾을 수 없습니다."),
+    FRIEND_REQUEST_NOT_PENDING(HttpStatus.BAD_REQUEST, "FRIEND4002", "이미 처리된 친구 요청입니다."),
+    CANNOT_ADD_SELF(HttpStatus.BAD_REQUEST, "FRIEND4003", "자기 자신에게는 친구 요청을 보낼 수 없습니다."),
+    FRIEND_ALREADY_EXISTS_OR_REQUESTED(HttpStatus.BAD_REQUEST, "FRIEND4004", "이미 친구이거나 요청을 보낸 상태입니다."),
 
     ;
 

--- a/src/main/java/com/umc/hwaroak/service/FriendService.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendService.java
@@ -2,4 +2,6 @@ package com.umc.hwaroak.service;
 
 public interface FriendService {
     void requestFriend(Long receiverId);
+
+    void acceptFriendRequest(Long senderId);
 }

--- a/src/main/java/com/umc/hwaroak/service/FriendService.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendService.java
@@ -1,0 +1,5 @@
+package com.umc.hwaroak.service;
+
+public interface FriendService {
+    void requestFriend(Long receiverId);
+}

--- a/src/main/java/com/umc/hwaroak/service/FriendService.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendService.java
@@ -4,4 +4,7 @@ public interface FriendService {
     void requestFriend(Long receiverId);
 
     void acceptFriendRequest(Long senderId);
+
+    void rejectFriendRequest(Long senderId);
+
 }

--- a/src/main/java/com/umc/hwaroak/service/FriendService.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendService.java
@@ -12,4 +12,6 @@ public interface FriendService {
     void rejectFriendRequest(Long senderId);
 
     List<FriendResponseDto.FriendInfo> getFriendList();
+
+    public List<FriendResponseDto.ReceivedRequestInfo> getReceivedFriendRequests();
 }

--- a/src/main/java/com/umc/hwaroak/service/FriendService.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendService.java
@@ -1,5 +1,9 @@
 package com.umc.hwaroak.service;
 
+import com.umc.hwaroak.dto.FriendResponseDto;
+
+import java.util.List;
+
 public interface FriendService {
     void requestFriend(Long receiverId);
 
@@ -7,4 +11,5 @@ public interface FriendService {
 
     void rejectFriendRequest(Long senderId);
 
+    List<FriendResponseDto.FriendInfo> getFriendList();
 }

--- a/src/main/java/com/umc/hwaroak/service/FriendService.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendService.java
@@ -13,5 +13,7 @@ public interface FriendService {
 
     List<FriendResponseDto.FriendInfo> getFriendList();
 
-    public List<FriendResponseDto.ReceivedRequestInfo> getReceivedFriendRequests();
+    List<FriendResponseDto.ReceivedRequestInfo> getReceivedFriendRequests();
+
+    void deleteFriend(Long friendMemberId);
 }

--- a/src/main/java/com/umc/hwaroak/service/FriendServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendServiceImpl.java
@@ -149,4 +149,28 @@ public class FriendServiceImpl implements FriendService {
                 })
                 .collect(Collectors.toList());
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<FriendResponseDto.ReceivedRequestInfo> getReceivedFriendRequests() {
+        Member me = getCurrentMember();
+
+        // [1] 상태가 REQUESTED이고, 내가 받은 요청만 최신순 정렬로 조회
+        List<Friend> requests = friendRepository.findAllByReceiverAndStatusOrderByCreatedAtDesc(
+                me, FriendStatus.REQUESTED
+        );
+
+        // [2] 요청 보낸 사람 정보를 DTO로 변환
+        return requests.stream()
+                .map(friend -> {
+                    Member sender = friend.getSender();
+                    return FriendResponseDto.ReceivedRequestInfo.builder()
+                            .memberId(sender.getId())
+                            .nickname(sender.getNickname())
+                            .introduction(sender.getIntroduction())
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/umc/hwaroak/service/FriendServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendServiceImpl.java
@@ -130,7 +130,7 @@ public class FriendServiceImpl implements FriendService {
 
         // [2] 내가 sender 또는 receiver로 포함된 친구 관계 중, 상태가 ACCEPTED인 것들 모두 조회
         // → 단방향으로 저장되어 있기 때문에 sender 또는 receiver 둘 다 체크 필요
-        List<Friend> acceptedFriends = friendRepository.findAllBySenderOrReceiverAndStatus(me, me, FriendStatus.ACCEPTED);
+        List<Friend> acceptedFriends = friendRepository.findAllAcceptedFriends(me);
 
         // [3] 각 친구 관계에서 "나"와 반대쪽에 있는 Member만 추출
         // → 그게 진짜 '친구'임

--- a/src/main/java/com/umc/hwaroak/service/FriendServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendServiceImpl.java
@@ -64,8 +64,8 @@ public class FriendServiceImpl implements FriendService {
         if (existingFriend.isPresent()) {
             Friend friend = existingFriend.get();
 
-            // [4-1] 기존 상태가 BLOCKED이면 상태를 REQUESTED로 바꿔 재요청 처리
-            if (friend.getStatus() == FriendStatus.BLOCKED) {
+            // [4-1] 기존 상태가 BLOCKED 또는 REJECTED 이면 상태를 REQUESTED로 바꿔 재요청 처리
+            if (friend.getStatus() == FriendStatus.BLOCKED || friend.getStatus() == FriendStatus.REJECTED) {
                 friend.updateStatus(FriendStatus.REQUESTED);
                 return;
             }

--- a/src/main/java/com/umc/hwaroak/service/FriendServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendServiceImpl.java
@@ -1,0 +1,68 @@
+package com.umc.hwaroak.service;
+
+import com.umc.hwaroak.domain.Friend;
+import com.umc.hwaroak.domain.Member;
+import com.umc.hwaroak.domain.common.FriendStatus;
+import com.umc.hwaroak.exception.GeneralException;
+import com.umc.hwaroak.repository.FriendRepository;
+import com.umc.hwaroak.repository.MemberRepository.MemberRepository;
+import com.umc.hwaroak.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FriendServiceImpl implements FriendService {
+
+    private final FriendRepository friendRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 친구 요청을 보냅니다.
+     * 요청 전에 다음 조건을 확인합니다:
+     * - 존재하지 않는 유저에게 요청 ❌
+     * - 자기 자신에게 요청 ❌
+     * - 이미 요청했거나 친구 상태인 경우 ❌
+     * 조건을 만족하면 Friend 엔티티를 저장합니다.
+     *
+     * @param receiverId 친구 요청을 받을 Member의 ID
+     */
+    @Override
+    @Transactional
+    public void requestFriend(Long receiverId) {
+        // [1] 현재 로그인된 유저를 가져옵니다. (나중에 인증 시스템으로 교체 필요)
+        Member sender = getCurrentMember();
+
+        // [2] 요청받을 유저가 존재하는지 확인
+        Member receiver = memberRepository.findById(receiverId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // [3] 자기 자신에게 친구 요청하는 경우 예외 처리
+        if (sender.getId().equals(receiver.getId())) {
+            throw new GeneralException(ErrorCode.CANNOT_ADD_SELF);
+        }
+
+        // [4] 이미 친구 요청을 보냈거나 친구 상태인지 확인 (양방향 모두 검사)
+        boolean alreadyExists =
+                friendRepository.existsBySenderAndReceiver(sender, receiver) ||
+                        friendRepository.existsBySenderAndReceiver(receiver, sender);
+
+        if (alreadyExists) {
+            throw new GeneralException(ErrorCode.FRIEND_ALREADY_EXISTS_OR_REQUESTED);
+        }
+
+        // [5] 친구 요청 엔티티 생성 및 저장
+        Friend friend = new Friend(sender, receiver, FriendStatus.REQUESTED);
+        friendRepository.save(friend);
+    }
+
+    /**
+     * 현재 로그인된 사용자를 임시로 반환합니다.
+     * TODO: 이후 JWT 인증 정보를 기반으로 실제 로그인 유저를 반환하도록 수정 필요
+     */
+    private Member getCurrentMember() {
+        return memberRepository.findById(1L) // 임시 고정 ID
+                .orElseThrow(() -> new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/umc/hwaroak/service/FriendServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendServiceImpl.java
@@ -28,7 +28,7 @@ public class FriendServiceImpl implements FriendService {
      * TODO: 이후 JWT 인증 정보를 기반으로 실제 로그인 유저를 반환하도록 수정 필요
      */
     private Member getCurrentMember() {
-        return memberRepository.findById(1L) // 임시 고정 ID
+        return memberRepository.findById(5L) // 임시 고정 ID
                 .orElseThrow(() -> new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
     }
 


### PR DESCRIPTION
## 📌 Related Issue
- Closes #16 

---
## ✨ Summary (작업 개요)
- 친구 목록 
- 친구 추가 요청 (REQUESTED)
- 친구 요청 수락 (ACCEPTED)
- 친구 요청 거절 (REJECTED)
- 받은 친구 요청 목록 최신순 조회 (REQUESTED DESC)
- 친구 삭제(soft delete = BLOCKED)


---
## 🛠 Work Description (작업 상세)

BaseEntity 활용을 위해 HwaroakApplication에 @EnableJpaAuditing 추가했습니다!

ENUM에 요청중(REQUESTED) , soft delete(BLOCKED) 추가했습니다.

특히 FriendRepository의 findAllAcceptedFriends() 함수는 Spring Data JPA 네이밍으로는 한계가 있어서, @Query로 확실하게 쿼리문을 짜서 ACCEPTED인 상태인 친구들만 가져오게끔 설정하였습니다.


---
## 🧪 Test Coverage

서비스 로직 맨 위, getCurrentMember()를 임시 로그인 로직으로 이용하여 테스트했습니다!

친구 요청 성공 스웨거 입니다!!
<img width="2874" height="1360" alt="image" src="https://github.com/user-attachments/assets/c4387880-0196-4576-9248-03d7278775cb" />



sender_id(로그인 한 사람) 이 receiver_id(2,4)에게 친구 요청을 하여 REQUESTED 상태로 두개의 요청이 갔습니다
<img width="1900" height="214" alt="image" src="https://github.com/user-attachments/assets/6ccb3e44-1ffb-43d2-ba95-7a3d1edb0182" />



다음은 각각 요청 받은 아이디로 수동 로그인 하여 요청을 수락하고, 거절 하는 스웨거 확인 화면입니다. 제가 각각 2 3번으로 들어가 1번 요청 수락하고 4번 계정은 1번 요청 거절 했습니다
<img width="2966" height="1416" alt="image" src="https://github.com/user-attachments/assets/7f4aeb25-4d8f-489f-bb64-3f61af1cbd8b" />
<img width="2988" height="1174" alt="image" src="https://github.com/user-attachments/assets/176d614d-4703-45ae-8f6a-667dbac021d5" />



그러면?! 각각 receiver_id로 로그인해서 한 행동들에 따라 각각 1번의 요청들이 ACCEPTED, REJECTED로 바뀌었습니다.
<img width="1924" height="328" alt="image" src="https://github.com/user-attachments/assets/3449a9b9-494e-49fc-b8e8-4eec810dc2f9" />


다음은 2번 계정으로 로그인하여 1번 계정 요청 삭제했습니다.
<img width="2950" height="1502" alt="image" src="https://github.com/user-attachments/assets/efea6be9-eb45-4ce2-a674-f3ad953bf560" />


그럼 아래 sender_id(1)의 친구요청이 receiver_id(2) 부분이 BLOCKED 된 것을 확인 할 수 있습니다.
<img width="1938" height="474" alt="image" src="https://github.com/user-attachments/assets/cfbeeeee-baeb-4387-ace2-e0590ddbfb61" />


다음은 5번으로 로그인하여 받은 요청들 받아왔는데 각각 sender_id가 멤버 id로 뜨며 잘 반환해주고 있습니다.
<img width="1473" height="701" alt="image" src="https://github.com/user-attachments/assets/2bb6cce2-7e8a-436e-80b5-2c3c03f87a1b" />

5번으로 로그인하여 2, 3 요청들 수락해서 친구 상태를 맺은다음
<img width="976" height="294" alt="image" src="https://github.com/user-attachments/assets/d848f68a-aa11-4a37-8647-14c4c6e26848" />


마지막으로 5번과 친구인 사람들을 조회했습니다. ACCEPTED로 바뀐 2번 3번이 잘 뜨고, 그들의 간단한 소개도 잘 뜹니다.
<img width="1456" height="625" alt="image" src="https://github.com/user-attachments/assets/cb39c1ed-7c21-4d4e-b257-2796256df1fb" />



---
## 😅 Uncompleted Tasks (미완료 작업)

친구 요청 시 알람 가는 기능 추가해야합니다!!! 현재는 ENUM만 바꾸기 입니다.

---
## 📢 To Reviewers

사진에 나오는 DB들에 created_At, upated_At이 없는데 좀 나중에 @EnableJpaAuditing 추가해서 그런 겁니다! 지금은 생성하면 잘 뜹니다.
그리고 최대한 요청, 수락, 거절, 조회 순으로 PR 작성해보긴 했는데 잘 읽히실지 모르겠네요.. 

메인 로직들에 최대한 주석 작성해놓긴 했는데 많은 질문과 리뷰 부탁드립니다.

저도 쓰면서 헷갈리는데, 요청 거절 == REJECTED 이고,  요청 삭제 == BLOCKED 입니다!!

에러 상황 나름 추가해보긴 했는데 추후에 테스트 더 해봐야 할 듯 합니다.

---
