### PR TITLE
refactor: 카카오로그인 response body 수정

### DIFF
--- a/src/main/java/com/umc/hwaroak/controller/AuthController.java
+++ b/src/main/java/com/umc/hwaroak/controller/AuthController.java
@@ -3,15 +3,15 @@ package com.umc.hwaroak.controller;
 import com.umc.hwaroak.dto.response.TokenDto;
 import com.umc.hwaroak.dto.request.KakaoLoginRequestDto;
 import com.umc.hwaroak.dto.response.KakaoLoginResponseDto;
+import com.umc.hwaroak.response.ApiResponse;
+import com.umc.hwaroak.response.SuccessCode;
 import com.umc.hwaroak.serviceImpl.KakaoAuthServiceImpl;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "Auth", description = "카카오 로그인 및 JWT 토큰 관련 API")
+@Tag(name = "Auth", description = "카카오 로그인 및 토큰 재발급 관련 API")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -19,22 +19,22 @@ public class AuthController {
 
     private final KakaoAuthServiceImpl kakaoAuthService;
 
-    @Operation(summary = "카카오 로그인", description = "카카오 accessToken으로 JWT access/refresh 토큰을 발급합니다.")
-    @ApiResponse(responseCode = "200", description = "JWT 토큰 발급 성공")
-    @ApiResponse(responseCode = "400", description = "잘못된 카카오 accessToken (INVALID_KAKAO_TOKEN)")
     @PostMapping("/kakao")
-    public ResponseEntity<KakaoLoginResponseDto> kakaoLogin(@RequestBody KakaoLoginRequestDto request) {
+    public ResponseEntity<ApiResponse<KakaoLoginResponseDto>> kakaoLogin(@RequestBody KakaoLoginRequestDto request) {
         KakaoLoginResponseDto response = kakaoAuthService.kakaoLogin(request.getAccessToken());
 
-        return ResponseEntity.ok(response);
+// 성공
+        return ResponseEntity
+                .status(SuccessCode.OK.getHttpStatus())
+                .body(ApiResponse.success(SuccessCode.OK, response));
     }
 
-    @Operation(summary = "토큰 재발급", description = "refreshToken을 이용해 accessToken을 재발급합니다.")
-    @ApiResponse(responseCode = "200", description = "액세스 토큰 재발급 성공")
-    @ApiResponse(responseCode = "400", description = "유효하지 않거나 만료된 refreshToken (INVALID_REFRESH_TOKEN)")
     @PostMapping("/reissue")
-    public ResponseEntity<TokenDto> reissue(@RequestBody TokenDto tokenRequest) {
+    public ResponseEntity<ApiResponse<TokenDto>> reissue(@RequestBody TokenDto tokenRequest) {
         TokenDto newTokens = kakaoAuthService.reissueTokens(tokenRequest);
-        return ResponseEntity.ok(newTokens);
+
+        return ResponseEntity
+                .status(SuccessCode.OK.getHttpStatus())
+                .body(ApiResponse.success(SuccessCode.OK, newTokens));
     }
 }

--- a/src/main/java/com/umc/hwaroak/controller/TestController.java
+++ b/src/main/java/com/umc/hwaroak/controller/TestController.java
@@ -5,6 +5,7 @@ import com.umc.hwaroak.response.ApiResponse;
 import com.umc.hwaroak.response.ErrorCode;
 import com.umc.hwaroak.response.SuccessCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,7 +26,7 @@ public class TestController {
     @GetMapping("/success/data")
     public ResponseEntity<?> getSuccessData() {
         return ResponseEntity.ok(
-                ApiResponse.of(SuccessCode.OK, "성공 응답 예시 확인")
+                ApiResponse.success(SuccessCode.OK)
         );
     }
 

--- a/src/main/java/com/umc/hwaroak/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/hwaroak/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.umc.hwaroak.exception;
 
+import com.umc.hwaroak.response.ApiResponse;
 import com.umc.hwaroak.response.ErrorCode;
 import com.umc.hwaroak.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -18,9 +19,11 @@ import java.nio.file.AccessDeniedException;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(GeneralException.class)
-    protected ResponseEntity<ErrorResponse> handlerGeneralException(GeneralException e, HttpServletRequest request) {
-        logError(e, request);
-        return ErrorResponse.of(e.getErrorCode());
+    protected ResponseEntity<ApiResponse<Void>> handlerGeneralException(GeneralException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.fail(errorCode));
     }
 
     @ExceptionHandler(AccessDeniedException.class)
@@ -38,9 +41,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handlerException(Exception e, HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<Void>> handlerException(Exception e, HttpServletRequest request) {
         logError(e, request);
-        return ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 
     private void logError(Exception e, HttpServletRequest request) {

--- a/src/main/java/com/umc/hwaroak/response/ApiResponse.java
+++ b/src/main/java/com/umc/hwaroak/response/ApiResponse.java
@@ -3,21 +3,32 @@ package com.umc.hwaroak.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Builder
 @Getter
 @AllArgsConstructor
 public class ApiResponse<T> {
 
+    private final String status;  // 예: OK, BAD_REQUEST
     private final String code;
     private final String message;
     private final T data;
 
-    public static ApiResponse<?> of(SuccessCode code) {
-        return new ApiResponse<>(code.getCode(), code.getMessage(), null);
+    // 내부에서 status 추출
+    public static <T> ApiResponse<T> success(SuccessCode code, T data) {
+        return new ApiResponse<>(code.getHttpStatus().name(), code.getCode(), code.getMessage(), data);
     }
 
-    public static <T> ApiResponse<?> of(SuccessCode code, T data) {
-        return new ApiResponse<>(code.getCode(), code.getMessage(), data);
+    public static ApiResponse<Void> success(SuccessCode code) {
+        return new ApiResponse<>(code.getHttpStatus().name(), code.getCode(), code.getMessage(), null);
+    }
+
+    public static ApiResponse<Void> fail(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getHttpStatus().name(), errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode, T data) {
+        return new ApiResponse<>(errorCode.getHttpStatus().name(), errorCode.getCode(), errorCode.getMessage(), data);
     }
 }

--- a/src/main/java/com/umc/hwaroak/response/ErrorCode.java
+++ b/src/main/java/com/umc/hwaroak/response/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode implements BaseCode{
     DIARY_ALREADY_RECORDED(HttpStatus.BAD_REQUEST, "DE4001", "일기는 하루만 기록할 수 있습니다."),
     DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DE4002", "해당 일기 ID가 존재하지 않습니다."),
 
-    // Auth
+    // kakao login
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"AUTH_002","유효하지 않은 refresh token입니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "메소드 요청이 잘못됐습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "접근 권한이 없습니다."),

--- a/src/main/java/com/umc/hwaroak/response/ResponseWrappingAdvice.java
+++ b/src/main/java/com/umc/hwaroak/response/ResponseWrappingAdvice.java
@@ -2,6 +2,7 @@ package com.umc.hwaroak.response;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.server.ServerHttpRequest;
@@ -39,6 +40,6 @@ public class ResponseWrappingAdvice implements ResponseBodyAdvice<Object> {
             return body;
         }
 
-        return ApiResponse.of(SuccessCode.OK, body);
+        return ApiResponse.success(SuccessCode.OK);
     }
 }

--- a/src/main/java/com/umc/hwaroak/serviceImpl/KakaoAuthServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/KakaoAuthServiceImpl.java
@@ -43,15 +43,11 @@ public class KakaoAuthServiceImpl implements KakaoAuthService {
         KakaoUserInfoDto.KakaoAccount account = kakaoUser.getKakao_account();
 
         if (account == null || account.getProfile() == null) {
-            throw new GeneralException(ErrorCode.UNAUTHORIZED_ACCESS);
+            throw new GeneralException(ErrorCode.MEMBER_NOT_FOUND);
         }
 
         String nickname = account.getProfile().getNickname();
         String profileImage = account.getProfile().getProfile_image_url();
-
-        if (nickname == null || profileImage == null) {
-            throw new GeneralException(ErrorCode.TEST_ERROR);
-        }
 
         Member member = memberRepository.findByUserId(kakaoId)
                 .orElseGet(() -> {


### PR DESCRIPTION
## 📌 Related Issue
> 관련 이슈가 있다면 작성해주세요
- Closes #31 

---
## ✨ Summary (작업 개요)
> 이번 PR에서 구현한 주요 기능 혹은 변경 사항을 간략히 설명해주세요.
카카오 로그인시 성공했을 때의 response body와 실패했을 때의 response body 필드를 맞추고 수정

---
## 🛠 Work Description (작업 상세)
> 무엇을 어떻게 변경/추가/삭제했는지 구체적으로 작성해주세요.
- 수정 전
<img width="1280" height="399" alt="image" src="https://github.com/user-attachments/assets/fc64997b-efba-4d25-b0ca-d01d8293d364" />
<img width="417" height="551" alt="image" src="https://github.com/user-attachments/assets/dde740b1-c282-4db6-b351-c572af84cc3f" />

성공했을 경우 데이터값을 return, 실패했을 경우 status, code, message를 return

이를 아래와같은 형식으로 바꿈
<img width="889" height="557" alt="image" src="https://github.com/user-attachments/assets/c440205a-437e-4d5b-8693-9ffe2130090a" />

---
## 🧪 Test Coverage
> 어떤 테스트를 했고, 어떤 결과를 얻었는지 작성해주세요.
성공시
<img width="366" height="438" alt="image" src="https://github.com/user-attachments/assets/a868d4dc-5b2b-43f1-972a-f04e293d92b2" />

실패시
<img width="589" height="420" alt="image" src="https://github.com/user-attachments/assets/40c1208b-f519-4ba5-9126-5579eca5b009" />


---
## 📢 To Reviewers
> 리뷰어에게 전달하고 싶은 내용이 있다면 작성해주세요.
> 중점적으로 봐줬으면 하는 부분이나, 리뷰에 도움이 될 참고자료가 있다면 공유해주세요.

간단한 response 수정입니다 !
---
