### PR TITLE
[feat] 친구 요청 시 알람 가기

### DIFF
--- a/src/main/java/com/umc/hwaroak/controller/AlarmController.java
+++ b/src/main/java/com/umc/hwaroak/controller/AlarmController.java
@@ -1,7 +1,10 @@
 package com.umc.hwaroak.controller;
 
+import com.umc.hwaroak.authentication.MemberLoader;
+import com.umc.hwaroak.domain.Member;
 import com.umc.hwaroak.dto.response.AlarmResponseDto;
 import com.umc.hwaroak.service.AlarmService;
+import com.umc.hwaroak.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,6 +20,15 @@ import java.util.List;
 public class AlarmController {
 
     private final AlarmService alarmService;
+    private final MemberLoader memberLoader;
+
+    @Operation(summary = "알림함 전체 조회", description = "로그인한 사용자의 모든 알람을 최신순으로 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공")
+    @GetMapping
+    public List<AlarmResponseDto.InfoDto> getAlarmList() {
+        Member member = memberLoader.getMemberByContextHolder();
+        return alarmService.getAllAlarmsForMember(member);
+    }
 
     @Operation(summary = "공지 목록 조회", description = "alarmType = NOTIFICATION 인 공지를 최신순으로 조회합니다.")
     @ApiResponse(responseCode = "200", description = "공지 목록 조회 성공")

--- a/src/main/java/com/umc/hwaroak/domain/Alarm.java
+++ b/src/main/java/com/umc/hwaroak/domain/Alarm.java
@@ -3,10 +3,16 @@ package com.umc.hwaroak.domain;
 import com.umc.hwaroak.domain.common.AlarmType;
 import com.umc.hwaroak.domain.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "alarm")
 public class Alarm extends BaseEntity {
     @Id

--- a/src/main/java/com/umc/hwaroak/dto/response/AlarmResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/response/AlarmResponseDto.java
@@ -9,10 +9,11 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
+@Schema(name = "알람 응답 DTO")
 public class AlarmResponseDto {
 
     /**
-     * 최신순 정렬용 Dto
+     * 알람 제목만.
      */
     @Builder
     @Getter
@@ -31,7 +32,7 @@ public class AlarmResponseDto {
     }
 
     /**
-     * 공지 상세보기용 Dto
+     * 알람 제목 + content(내용) , 현재 message 안쓰는중
      */
     @Builder
     @Getter

--- a/src/main/java/com/umc/hwaroak/dto/response/AlarmResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/response/AlarmResponseDto.java
@@ -1,5 +1,6 @@
 package com.umc.hwaroak.dto.response;
 
+import com.umc.hwaroak.domain.common.AlarmType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,13 +20,13 @@ public class AlarmResponseDto {
     @AllArgsConstructor
     public static class PreviewDto {
 
-        @Schema(description = "공지 ID", example = "1")
+        @Schema(description = "알람 ID", example = "1")
         private Long id;
 
-        @Schema(description = "공지 제목", example = "서버 점검 안내")
+        @Schema(description = "알람 제목", example = "서버 점검 안내")
         private String title;
 
-        @Schema(description = "공지 생성일", example = "2025-07-14")
+        @Schema(description = "알람 생성일", example = "2025-07-14")
         private LocalDate createdAt; // 프론트에서 언제 올라온 공지인지 정렬 및 표시용
     }
 
@@ -38,16 +39,19 @@ public class AlarmResponseDto {
     @AllArgsConstructor
     public static class InfoDto {
 
-        @Schema(description = "공지 ID", example = "1")
+        @Schema(description = "알람 ID", example = "1")
         private Long id;
 
-        @Schema(description = "공지 제목", example = "서버 점검 안내")
+        @Schema(description = "알람 제목", example = "친구 요청")
         private String title;
 
-        @Schema(description = "공지 내용", example = "7월 16일 03시부터 서버 점검이 진행됩니다.")
+        @Schema(description = "공지 내용", example = "OO님이 친구요청을 보냈습니다.")
         private String content;
 
-        @Schema(description = "공지 생성일", example = "2025-07-14")
+        @Schema(description = "알람 종류", example = "친구요청")
+        private AlarmType alarmType;
+
+        @Schema(description = "알람 생성일", example = "2025-07-14")
         private LocalDate createdAt;
     }
 }

--- a/src/main/java/com/umc/hwaroak/repository/AlarmRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/AlarmRepository.java
@@ -1,6 +1,7 @@
 package com.umc.hwaroak.repository;
 
 import com.umc.hwaroak.domain.Alarm;
+import com.umc.hwaroak.domain.Member;
 import com.umc.hwaroak.domain.common.AlarmType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -14,4 +15,8 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     // 공지 상세 -> 이것도 현재 이름만 공지 상세지 타입과 이름으로 조회하는 것이기에 활용가능 합니다!
     Optional<Alarm> findByIdAndAlarmType(Long id, AlarmType alarmType);
+
+    // 모든 알람 조회 -> 알람함 누르면 최신순으로 쫘라락 뜨게끔.
+    List<Alarm> findAllByReceiverOrderByCreatedAtDesc(Member receiver);
+
 }

--- a/src/main/java/com/umc/hwaroak/response/ResponseWrappingAdvice.java
+++ b/src/main/java/com/umc/hwaroak/response/ResponseWrappingAdvice.java
@@ -40,6 +40,6 @@ public class ResponseWrappingAdvice implements ResponseBodyAdvice<Object> {
             return body;
         }
 
-        return ApiResponse.success(SuccessCode.OK);
+        return ApiResponse.success(SuccessCode.OK, body);
     }
 }

--- a/src/main/java/com/umc/hwaroak/service/AlarmService.java
+++ b/src/main/java/com/umc/hwaroak/service/AlarmService.java
@@ -20,4 +20,10 @@ public interface AlarmService {
      *  친구 요청 알람 보내기
      */
     void sendFriendRequestAlarm(Member sender, Member receiver);
+
+    /**
+     * 로그인한 유저의 알림함 전체를 최신순으로 조회
+     */
+    List<AlarmResponseDto.InfoDto> getAllAlarmsForMember(Member member);
+
 }

--- a/src/main/java/com/umc/hwaroak/service/AlarmService.java
+++ b/src/main/java/com/umc/hwaroak/service/AlarmService.java
@@ -1,5 +1,6 @@
 package com.umc.hwaroak.service;
 
+import com.umc.hwaroak.domain.Member;
 import com.umc.hwaroak.dto.response.AlarmResponseDto;
 
 import java.util.List;
@@ -14,4 +15,9 @@ public interface AlarmService {
      * 공지 상세보기
      */
     AlarmResponseDto.InfoDto getNoticeDetail(Long id);
+
+    /**
+     *  친구 요청 알람 보내기
+     */
+    void sendFriendRequestAlarm(Member sender, Member receiver);
 }

--- a/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
@@ -78,8 +78,8 @@ public class AlarmServiceImpl implements AlarmService {
     }
 
     @Override
-    public List<AlarmResponseDto.InfoDto> getAllAlarmsForMember(Member member) {
-        List<Alarm> alarms = alarmRepository.findAllByReceiverOrderByCreatedAtDesc(member);
+    public List<AlarmResponseDto.InfoDto> getAllAlarmsForMember(Member receiver) {
+        List<Alarm> alarms = alarmRepository.findAllByReceiverOrderByCreatedAtDesc(receiver);
 
         return alarms.stream()
                 .map(alarm -> AlarmResponseDto.InfoDto.builder()

--- a/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
@@ -2,6 +2,7 @@ package com.umc.hwaroak.serviceImpl;
 
 import com.umc.hwaroak.authentication.MemberLoader;
 import com.umc.hwaroak.domain.Alarm;
+import com.umc.hwaroak.domain.Member;
 import com.umc.hwaroak.domain.common.AlarmType;
 import com.umc.hwaroak.dto.response.AlarmResponseDto;
 import com.umc.hwaroak.exception.GeneralException;
@@ -56,5 +57,24 @@ public class AlarmServiceImpl implements AlarmService {
                 .content(alarm.getContent())
                 .createdAt(alarm.getCreatedAt())
                 .build();
+    }
+
+    /**
+     *  친구 요청시 알람 생성하기
+     */
+    @Override
+    public void sendFriendRequestAlarm(Member sender, Member receiver) {
+        String nickname = sender.getNickname();
+
+        Alarm alarm = Alarm.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .alarmType(AlarmType.FRIEND_REQUEST)
+                .title("친구 요청")
+                .message(nickname + "님이 친구 요청을 보냈습니다.")
+                .content("알림함에서 요청을 확인할 수 있습니다.")
+                .build();
+
+        alarmRepository.save(alarm);
     }
 }

--- a/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
@@ -71,10 +71,25 @@ public class AlarmServiceImpl implements AlarmService {
                 .receiver(receiver)
                 .alarmType(AlarmType.FRIEND_REQUEST)
                 .title("친구 요청")
-                .message(nickname + "님이 친구 요청을 보냈습니다.")
-                .content("알림함에서 요청을 확인할 수 있습니다.")
+                .content(nickname + "님이 친구 요청을 보냈습니다.")
                 .build();
 
         alarmRepository.save(alarm);
     }
+
+    @Override
+    public List<AlarmResponseDto.InfoDto> getAllAlarmsForMember(Member member) {
+        List<Alarm> alarms = alarmRepository.findAllByReceiverOrderByCreatedAtDesc(member);
+
+        return alarms.stream()
+                .map(alarm -> AlarmResponseDto.InfoDto.builder()
+                        .id(alarm.getId())
+                        .title(alarm.getTitle())
+                        .content(alarm.getContent())
+                        .alarmType(alarm.getAlarmType())
+                        .createdAt(alarm.getCreatedAt())
+                        .build())
+                .toList();
+    }
+
 }

--- a/src/main/java/com/umc/hwaroak/serviceImpl/FriendServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/FriendServiceImpl.java
@@ -6,9 +6,11 @@ import com.umc.hwaroak.domain.Member;
 import com.umc.hwaroak.domain.common.FriendStatus;
 import com.umc.hwaroak.dto.response.FriendResponseDto;
 import com.umc.hwaroak.exception.GeneralException;
+import com.umc.hwaroak.repository.AlarmRepository;
 import com.umc.hwaroak.repository.FriendRepository;
 import com.umc.hwaroak.repository.MemberRepository;
 import com.umc.hwaroak.response.ErrorCode;
+import com.umc.hwaroak.service.AlarmService;
 import com.umc.hwaroak.service.FriendService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,6 +27,7 @@ public class FriendServiceImpl implements FriendService {
     private final MemberLoader memberLoader;
     private final FriendRepository friendRepository;
     private final MemberRepository memberRepository;
+    private final AlarmService alarmService;
 
     /**
      * 친구 요청을 보냅니다.
@@ -76,6 +79,9 @@ public class FriendServiceImpl implements FriendService {
         // [6] 친구 요청 엔티티 생성 및 저장
         Friend friend = new Friend(sender, receiver, FriendStatus.REQUESTED);
         friendRepository.save(friend);
+
+        // 👉 알람 전송
+        alarmService.sendFriendRequestAlarm(sender, receiver);
     }
 
 


### PR DESCRIPTION
## 📌 Related Issue
- Closes #21

---
## ✨ Summary (작업 개요)
친구 요청 시 알람 가기 구현
알람함 조회 기능 구현

---
## 🛠 Work Description (작업 상세)

친구 요청시 친구 요청(FRIEND_REQUEST) 알람 생성 했습니다. (service로직 추가 후 친구 요청시 알람 생성 되게끔 흐름 설정)

알람함 조회 기능 구현했습니다(recieverId로 조회하는 jpa 설정 추가, AlarmService, AlarmController 로직 추가)


---
## ⚠️ Trouble Shooting (문제 해결)


---
## 🧪 Test Coverage
유수님 아이디(제 더미데이터에선 테스트1)로 친구요청 보낸다음에 DB에서 수동으로 테스트를 위해 memberId 2번 멤버가 1번 멤버에게 친구요청 보낸거로 바꾸고 알람함 조회 실시했습니다! 좀 이상(?)하지만 잘 뜹니다. -> 이름은 id만 수동으로 바꾼거라 테스트1 이지만, 2번이 1번에게 보낸 친구요청 알람 잘 뜹니다.
<img width="1330" height="430" alt="image" src="https://github.com/user-attachments/assets/9123e01c-96e1-4e8b-a005-40a0d94b5eb9" />

그리고 DB에 더미데이터로 아래와 같이 있는 모든 알람 조회하면 잘 뜹니다.
<img width="936" height="142" alt="image" src="https://github.com/user-attachments/assets/076832be-1976-466b-a13c-c55438472fb3" />




---
## 😅 Uncompleted Tasks (미완료 작업)

---
## 📢 To Reviewers
현재 nickname+님이 친구요청을 보냈습니다 하고 알람 옵니다. nickname vs name PM님께 여쭤보겠습니다.

현재 스웨거에 공지 목록 조회 api는 설계한데로 응답 예시가 잘 뜨는데, 공지 상세조회 응답예시가 자꾸 멤버 관련 응답예시로 오류납니다.. @Schema 잘 설정했는데... 왜그럴까요?

그리고 지금 알람함 전체 조회가 결국은 내가 받은 요청을 가져와야 하기 때문에 알람의 recieverId로 알람을 조회하고 있는데, 그럼 공지의 경우는 어떻게 해야할지 막막합니다. 공지는 PM님 요구사항 상 필요 시 수동 등록이여야 하고, 아직 공지 수동 등록 api를 만들진 않았지만,, 공지의 recieverId는 두지 않고 recieverId가 null인 경우에도 반환할까? 이런식으로 생각이 들긴 합니다. 혹시 좋은 생각 있으시면 추천 부탁드려요~

---
