### PR TITLE
[feat] 회원 고유아이디 발급 및 인증 재설정

### DIFF
--- a/src/main/java/com/umc/hwaroak/authentication/JwtTokenProvider.java
+++ b/src/main/java/com/umc/hwaroak/authentication/JwtTokenProvider.java
@@ -38,20 +38,20 @@ public class JwtTokenProvider {
         return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String createAccessToken(String userId) {
-        return createToken(userId, accessTokenValidity);
+    public String createAccessToken(Long memberId) {
+        return createToken(memberId, accessTokenValidity);
     }
 
-    public String createRefreshToken(String userId) {
-        return createToken(userId, refreshTokenValidity);
+    public String createRefreshToken(Long memberId) {
+        return createToken(memberId, refreshTokenValidity);
     }
 
-    private String createToken(String userId, long validity) {
+    private String createToken(Long memberId, long validity) {
         Date now = new Date();
         Key key = getSigningKey();
 
         return Jwts.builder()
-                .setSubject(userId)
+                .setSubject(String.valueOf(memberId))
                 .claim("authority", "ROLE_USER")
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + validity))
@@ -60,7 +60,7 @@ public class JwtTokenProvider {
     }
 
     // 토큰에서 사용자 id 추출
-    public String getUserId(String token) {
+    public String getMemberId(String token) {
         Key key = getSigningKey();
         Claims claims = Jwts.parser()
                 .setSigningKey(key)
@@ -107,6 +107,6 @@ public class JwtTokenProvider {
                         .map(SimpleGrantedAuthority::new)
                         .collect(Collectors.toList());
 
-        return new UsernamePasswordAuthenticationToken(getUserId(token), null, authorities);
+        return new UsernamePasswordAuthenticationToken(getMemberId(token), null, authorities);
     }
 }

--- a/src/main/java/com/umc/hwaroak/authentication/JwtTokenProvider.java
+++ b/src/main/java/com/umc/hwaroak/authentication/JwtTokenProvider.java
@@ -38,20 +38,20 @@ public class JwtTokenProvider {
         return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String createAccessToken(Long userId) {
+    public String createAccessToken(String userId) {
         return createToken(userId, accessTokenValidity);
     }
 
-    public String createRefreshToken(Long userId) {
+    public String createRefreshToken(String userId) {
         return createToken(userId, refreshTokenValidity);
     }
 
-    private String createToken(Long userId, long validity) {
+    private String createToken(String userId, long validity) {
         Date now = new Date();
         Key key = getSigningKey();
 
         return Jwts.builder()
-                .setSubject(String.valueOf(userId))
+                .setSubject(userId)
                 .claim("authority", "ROLE_USER")
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + validity))
@@ -60,13 +60,13 @@ public class JwtTokenProvider {
     }
 
     // 토큰에서 사용자 id 추출
-    public Long getUserId(String token) {
+    public String getUserId(String token) {
         Key key = getSigningKey();
         Claims claims = Jwts.parser()
                 .setSigningKey(key)
                 .parseClaimsJws(token)
                 .getBody();
-        return Long.parseLong(claims.getSubject());
+        return claims.getSubject();
     }
 
     // 토큰 유효성 검증
@@ -107,8 +107,6 @@ public class JwtTokenProvider {
                         .map(SimpleGrantedAuthority::new)
                         .collect(Collectors.toList());
 
-        return new UsernamePasswordAuthenticationToken(String.valueOf(getUserId(token)), null, authorities);
+        return new UsernamePasswordAuthenticationToken(getUserId(token), null, authorities);
     }
-
 }
-

--- a/src/main/java/com/umc/hwaroak/authentication/MemberLoader.java
+++ b/src/main/java/com/umc/hwaroak/authentication/MemberLoader.java
@@ -29,17 +29,15 @@ public class MemberLoader {
         }
 
         Object principal = authentication.getPrincipal();
-        Long memberId;
+        String userId;
 
-        if (principal instanceof Long) {
-            memberId = (Long) principal;
-        } else if (principal instanceof String) {
-            memberId = Long.parseLong((String) principal);
+        if (principal instanceof String) {
+            userId = (String) principal;
         } else {
             throw new GeneralException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        return memberRepository.findById(memberId)
+        return memberRepository.findByUserId(userId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/umc/hwaroak/authentication/MemberLoader.java
+++ b/src/main/java/com/umc/hwaroak/authentication/MemberLoader.java
@@ -29,15 +29,9 @@ public class MemberLoader {
         }
 
         Object principal = authentication.getPrincipal();
-        String userId;
+        Long memberId = Long.parseLong((String) principal);
 
-        if (principal instanceof String) {
-            userId = (String) principal;
-        } else {
-            throw new GeneralException(ErrorCode.UNAUTHORIZED_ACCESS);
-        }
-
-        return memberRepository.findByUserId(userId)
+        return memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/umc/hwaroak/domain/Member.java
+++ b/src/main/java/com/umc/hwaroak/domain/Member.java
@@ -22,7 +22,7 @@ public class Member extends BaseEntity {
     @Column(name = "member_id", nullable = false)
     private Long id;
 
-    @Column(name = "user_id")
+    @Column(name = "user_id", nullable = false)
     private String userId;
 
     @Column(name = "name")

--- a/src/main/java/com/umc/hwaroak/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/response/MemberResponseDto.java
@@ -15,6 +15,9 @@ public class MemberResponseDto {
     @Schema(description = "회원 정보 조회 응답 DTO")
     public static class InfoDto {
 
+        @Schema(name = "회원ID", description = "파싱 처리 위한 회원 ID")
+        private Long memberId;
+
         @Schema(description = "유저 아이디", example = "a123456789")
         String userId;
 

--- a/src/main/java/com/umc/hwaroak/dto/response/TokenDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/response/TokenDto.java
@@ -1,17 +1,16 @@
 package com.umc.hwaroak.dto.response;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class TokenDto {
+
     private String accessToken;
     private String refreshToken;
+
     public TokenDto(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
     }
-
 }
 

--- a/src/main/java/com/umc/hwaroak/response/ErrorCode.java
+++ b/src/main/java/com/umc/hwaroak/response/ErrorCode.java
@@ -25,9 +25,11 @@ public enum ErrorCode implements BaseCode{
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"AUTH_002","유효하지 않은 refresh token입니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "메소드 요청이 잘못됐습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "접근 권한이 없습니다."),
-    FAILED_UUID(HttpStatus.BAD_REQUEST, "UE4001", "UUID 생성에 실패하였습니다."),
     FAILED_KAKAO_PROFILE(HttpStatus.BAD_REQUEST, "KE4001", "카카오 서버로부터 프로필을 얻는 데에 실패하였습니다."),
     NOT_ENOUGH_INFO(HttpStatus.NOT_FOUND, "KE4002", "카카오로부터 얻은 정보가 충분하지 않습니다."),
+
+    // UID
+    FAILED_UUID(HttpStatus.BAD_REQUEST, "UE4001", "UUID 생성에 실패하였습니다."),
 
     // Notice 관련
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NO4041", "해당 공지를 찾을 수 없습니다."),

--- a/src/main/java/com/umc/hwaroak/response/ErrorCode.java
+++ b/src/main/java/com/umc/hwaroak/response/ErrorCode.java
@@ -25,6 +25,9 @@ public enum ErrorCode implements BaseCode{
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"AUTH_002","유효하지 않은 refresh token입니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "메소드 요청이 잘못됐습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "접근 권한이 없습니다."),
+    FAILED_UUID(HttpStatus.BAD_REQUEST, "UE4001", "UUID 생성에 실패하였습니다."),
+    FAILED_KAKAO_PROFILE(HttpStatus.BAD_REQUEST, "KE4001", "카카오 서버로부터 프로필을 얻는 데에 실패하였습니다."),
+    NOT_ENOUGH_INFO(HttpStatus.NOT_FOUND, "KE4002", "카카오로부터 얻은 정보가 충분하지 않습니다."),
 
     // Notice 관련
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NO4041", "해당 공지를 찾을 수 없습니다."),

--- a/src/main/java/com/umc/hwaroak/serviceImpl/KakaoAuthServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/KakaoAuthServiceImpl.java
@@ -61,8 +61,8 @@ public class KakaoAuthServiceImpl implements KakaoAuthService {
                     return memberRepository.save(newMember);
                 });
 
-        String accessToken = jwtProvider.createAccessToken(member.getUserId());
-        String refreshToken = jwtProvider.createRefreshToken(member.getUserId());
+        String accessToken = jwtProvider.createAccessToken(member.getId());
+        String refreshToken = jwtProvider.createRefreshToken(member.getId());
 
         redisTemplate.opsForValue().set(
                 "RT:" + member.getId(), refreshToken,
@@ -80,14 +80,14 @@ public class KakaoAuthServiceImpl implements KakaoAuthService {
             throw new GeneralException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        String userId = jwtProvider.getUserId(refreshToken);
-        String storedRefreshToken = redisTemplate.opsForValue().get("RT:" + userId);
+        String memberId = jwtProvider.getMemberId(refreshToken);
+        String storedRefreshToken = redisTemplate.opsForValue().get("RT:" + memberId);
 
         if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
             throw new GeneralException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        String newAccessToken = jwtProvider.createAccessToken(userId);
+        String newAccessToken = jwtProvider.createAccessToken(Long.parseLong(memberId));
         return new TokenDto(newAccessToken, refreshToken);
     }
 

--- a/src/main/java/com/umc/hwaroak/serviceImpl/KakaoAuthServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/KakaoAuthServiceImpl.java
@@ -51,7 +51,7 @@ public class KakaoAuthServiceImpl implements KakaoAuthService {
 
         KakaoUserInfoDto kakaoUser = getUserInfoFromKakao(kakaoAccessToken);
 
-        String uid = uidGenerator.generatedUid(String.valueOf(kakaoUser.getId()));
+        String uid = uidGenerator.generateShortUid(String.valueOf(kakaoUser.getId()));
         KakaoUserInfoDto.KakaoAccount account = kakaoUser.getKakao_account();
 
         if (account == null || account.getProfile() == null) {

--- a/src/main/java/com/umc/hwaroak/serviceImpl/MemberServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/MemberServiceImpl.java
@@ -34,6 +34,7 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(()->new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
 
         return MemberResponseDto.InfoDto.builder()
+                .memberId(member.getId())
                 .userId(member.getUserId())
                 .nickname(member.getNickname())
                 .introduction(member.getIntroduction())

--- a/src/main/java/com/umc/hwaroak/util/UidGenerator.java
+++ b/src/main/java/com/umc/hwaroak/util/UidGenerator.java
@@ -2,27 +2,31 @@ package com.umc.hwaroak.util;
 
 import com.umc.hwaroak.exception.GeneralException;
 import com.umc.hwaroak.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
 @Component
+@RequiredArgsConstructor
 public class UidGenerator {
 
-    public String generatedUid(String kakaoId) {
+    public static String generateShortUid(String kakaoId) {
         try {
-            // 1. SHA-256 해시
+            // byte[] 변환 후 SHA-256 해싱
+            byte[] inputBytes = kakaoId.getBytes(StandardCharsets.UTF_8);
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(kakaoId.getBytes(StandardCharsets.UTF_8));
+            byte[] hash = digest.digest(inputBytes);
 
-            // 2. encoding by Base64
-            String base64 = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+            // Base64 URL-safe encoding 후 앞 16자리 사용
+            return Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(hash)
+                    .substring(0, 16);
 
-            // 3. 일부만 사용
-            return base64.substring(0, 16);
-        } catch (Exception e) {
+        } catch (NoSuchAlgorithmException e) {
             throw new GeneralException(ErrorCode.FAILED_UUID);
         }
     }

--- a/src/main/java/com/umc/hwaroak/util/UidGenerator.java
+++ b/src/main/java/com/umc/hwaroak/util/UidGenerator.java
@@ -1,0 +1,29 @@
+package com.umc.hwaroak.util;
+
+import com.umc.hwaroak.exception.GeneralException;
+import com.umc.hwaroak.response.ErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+
+@Component
+public class UidGenerator {
+
+    public String generatedUid(String kakaoId) {
+        try {
+            // 1. SHA-256 해시
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(kakaoId.getBytes(StandardCharsets.UTF_8));
+
+            // 2. encoding by Base64
+            String base64 = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+
+            // 3. 일부만 사용
+            return base64.substring(0, 16);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorCode.FAILED_UUID);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
- Closes #42 

---
## ✨ Summary (작업 개요)
- 회원의 고유한 유저아이디를 생성 로직 구현

---
## 🛠 Work Description (작업 상세)
- 카카오에서 얻은 회원 정보 ID를 기반으로 고유한 유저아이디를 생성하였습니다
- `UidGenerator.class` : 고유한 카카오 아이디를 기반으로 해싱 후 Base64 인코딩한 값 자른 유저아이디 생성
- 카카오 아이디가 변하지 않는 이상 동일한 유저아이디가 생성되므로 고유성 존재 ( 삭제 후 재생성으로 테스트 완료!! )
- Authentication을 DB의 MemberID 기반으로 작성하였으며, 서비스에서 사용될 유저아이디와의 혼동을 방지하기 위하여 이름을 전부 구분하였습니다( ex. getUserId(String token) -> getMemberId(String token))


---
## 🧪 Test Coverage
- 회원 생성 확인
<img width="370" height="314" alt="image" src="https://github.com/user-attachments/assets/39bdd4a1-4843-440b-b01b-341a12f756a4" />

- Authentication 제대로 작동되는지 확인( 여러명의 회원 중에서 대상 회원 조회 성공 )
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4567fa81-2b8e-452f-a783-2b8e84e11081" />

---
## 📢 To Reviewers
- 어떤 값을 기반으로 Authentication을 설정할지 고민을 했는데 로컬에서도 토큰 테스트가 돼서 MemberDB 통합이 필요없어서 Member ID(PK)를 기반으로 설계하는 형식으로 진행했습니다!
- 유저아이디를 생성하는 과정에서 uuid가 너무 길어서 인코딩 후에 16자리로 잘랐는데, 충돌가능성은 정말 드물다고는 하지만 나중에 중복될 경우에 대하여 새로 발급 받는 로직을 추가해야할 것 같습니다... 근데 이 과정은 좀더 생각해볼게요
- @yc3697 회원 조회 관련해서 프론트엔드가 파싱하기에는 MemberID가 필요할 수도 있을 것 같아 MemberID도 DTO에 추가했습니다!!


---
