### PR TITLE
feat: 공지 수동 등록 api 구현(#53)

### DIFF
--- a/src/main/java/com/umc/hwaroak/controller/AlarmController.java
+++ b/src/main/java/com/umc/hwaroak/controller/AlarmController.java
@@ -2,6 +2,7 @@ package com.umc.hwaroak.controller;
 
 import com.umc.hwaroak.authentication.MemberLoader;
 import com.umc.hwaroak.domain.Member;
+import com.umc.hwaroak.dto.request.AlarmRequestDto;
 import com.umc.hwaroak.dto.response.AlarmResponseDto;
 import com.umc.hwaroak.service.AlarmService;
 import com.umc.hwaroak.service.MemberService;
@@ -44,4 +45,12 @@ public class AlarmController {
     public AlarmResponseDto.InfoDto getNoticeDetail(@PathVariable Long id) {
         return alarmService.getNoticeDetail(id);
     }
+
+    @Operation(summary = "공지 등록", description = "관리자가 공지를 수동 등록합니다.")
+    @ApiResponse(responseCode = "201", description = "공지 등록 성공")
+    @PostMapping("/notices")
+    public void createNotice(@RequestBody AlarmRequestDto.CreateNoticeDto requestDto) {
+        alarmService.createNotice(requestDto);
+    }
+
 }

--- a/src/main/java/com/umc/hwaroak/domain/Alarm.java
+++ b/src/main/java/com/umc/hwaroak/domain/Alarm.java
@@ -40,4 +40,7 @@ public class Alarm extends BaseEntity {
 
     @Column(name = "content")
     private String content;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead = false;
 }

--- a/src/main/java/com/umc/hwaroak/dto/request/AlarmRequestDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/request/AlarmRequestDto.java
@@ -1,0 +1,15 @@
+package com.umc.hwaroak.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AlarmRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class CreateNoticeDto {
+        private String title;
+        private String content;
+        private String message;
+    }
+}

--- a/src/main/java/com/umc/hwaroak/service/AlarmService.java
+++ b/src/main/java/com/umc/hwaroak/service/AlarmService.java
@@ -1,6 +1,7 @@
 package com.umc.hwaroak.service;
 
 import com.umc.hwaroak.domain.Member;
+import com.umc.hwaroak.dto.request.AlarmRequestDto;
 import com.umc.hwaroak.dto.response.AlarmResponseDto;
 
 import java.util.List;
@@ -26,4 +27,8 @@ public interface AlarmService {
      */
     List<AlarmResponseDto.InfoDto> getAllAlarmsForMember(Member member);
 
+    /**
+     *  공지 수동 등록
+     */
+    void createNotice(AlarmRequestDto.CreateNoticeDto requestDto);
 }

--- a/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
@@ -4,6 +4,7 @@ import com.umc.hwaroak.authentication.MemberLoader;
 import com.umc.hwaroak.domain.Alarm;
 import com.umc.hwaroak.domain.Member;
 import com.umc.hwaroak.domain.common.AlarmType;
+import com.umc.hwaroak.dto.request.AlarmRequestDto;
 import com.umc.hwaroak.dto.response.AlarmResponseDto;
 import com.umc.hwaroak.exception.GeneralException;
 import com.umc.hwaroak.repository.AlarmRepository;
@@ -11,6 +12,7 @@ import com.umc.hwaroak.response.ErrorCode;
 import com.umc.hwaroak.service.AlarmService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -90,6 +92,24 @@ public class AlarmServiceImpl implements AlarmService {
                         .createdAt(alarm.getCreatedAt())
                         .build())
                 .toList();
+    }
+
+    /**
+     *  공지 수동 등록
+     */
+    @Transactional
+    public void createNotice(AlarmRequestDto.CreateNoticeDto requestDto) {
+        Alarm alarm = Alarm.builder()
+                .alarmType(AlarmType.NOTIFICATION)
+                .receiver(null)
+                .sender(null) // 필요 시 admin 계정 넣을 수도 있음
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .message(requestDto.getMessage())
+                .isRead(false)
+                .build();
+
+        alarmRepository.save(alarm);
     }
 
 }


### PR DESCRIPTION
## 📌 Related Issue
> 관련 이슈가 있다면 작성해주세요
- Closes #53 

---
## ✨ Summary (작업 개요)

공지 수동 생성 api 구현했습니다. 

---
## 🛠 Work Description (작업 상세)

 AlarmController, Service 수정


---
## ⚠️ Trouble Shooting (문제 해결)


---
## 🧪 Test Coverage
공지 내용에 현재 저의 고민을 넣어봤습니다.
eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIiwidG9rZW5UeXBlIjoiQUNDRVNTIiwiaWF0IjoxNzUzMTcxMDIyLCJleHAiOjE3NTU3NjMwMjJ9.wegBuoiQkK2EPS-7MaAX9KA2KbLYCGcP8FY_U-BPanY

receiverId=NULL 로 잘 생성되네요!
<img width="977" height="155" alt="image" src="https://github.com/user-attachments/assets/c191f8b7-a964-4ca5-bbc8-654ae582fada" />


---
## 😅 Uncompleted Tasks (미완료 작업)

---
## 📢 To Reviewers

---
