### PR TITLE
Fix/50 alarm read

### DIFF
--- a/src/main/java/com/umc/hwaroak/controller/AlarmController.java
+++ b/src/main/java/com/umc/hwaroak/controller/AlarmController.java
@@ -44,4 +44,13 @@ public class AlarmController {
     public AlarmResponseDto.InfoDto getNoticeDetail(@PathVariable Long id) {
         return alarmService.getNoticeDetail(id);
     }
+
+    @Operation(summary = "알림 읽음 처리", description = "알림을 읽음 처리합니다.")
+    @ApiResponse(responseCode = "200", description = "읽음 처리 성공")
+    @ApiResponse(responseCode = "4041", description = "알림 없음 (ALARM_NOT_FOUND)")
+    @PatchMapping("/{id}/read")
+    public void readAlarm(@PathVariable("id") Long alarmId) {
+        Member member = memberLoader.getMemberByContextHolder();
+        alarmService.markAsRead(alarmId, member);
+    }
 }

--- a/src/main/java/com/umc/hwaroak/domain/Alarm.java
+++ b/src/main/java/com/umc/hwaroak/domain/Alarm.java
@@ -40,4 +40,11 @@ public class Alarm extends BaseEntity {
 
     @Column(name = "content")
     private String content;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead = false;
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/com/umc/hwaroak/repository/AlarmRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/AlarmRepository.java
@@ -4,6 +4,8 @@ import com.umc.hwaroak.domain.Alarm;
 import com.umc.hwaroak.domain.Member;
 import com.umc.hwaroak.domain.common.AlarmType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,7 +18,16 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     // 공지 상세 -> 이것도 현재 이름만 공지 상세지 타입과 이름으로 조회하는 것이기에 활용가능 합니다!
     Optional<Alarm> findByIdAndAlarmType(Long id, AlarmType alarmType);
 
-    // 모든 알람 조회 -> 알람함 누르면 최신순으로 쫘라락 뜨게끔.
-    List<Alarm> findAllByReceiverOrderByCreatedAtDesc(Member receiver);
+    /**
+     * 알람함 최신순 전체 조회
+     * receiverId로 조회 or (receiverId=NULL && 공지)
+     */
+    @Query("""
+        SELECT a FROM Alarm a
+        WHERE a.receiver = :receiver
+           OR (a.receiver IS NULL AND a.alarmType = 'NOTIFICATION')
+        ORDER BY a.createdAt DESC
+    """)
+    List<Alarm> findAllIncludingNotifications(@Param("receiver") Member receiver);
 
 }

--- a/src/main/java/com/umc/hwaroak/response/ErrorCode.java
+++ b/src/main/java/com/umc/hwaroak/response/ErrorCode.java
@@ -31,8 +31,10 @@ public enum ErrorCode implements BaseCode{
     // UID
     FAILED_UUID(HttpStatus.BAD_REQUEST, "UE4001", "UUID 생성에 실패하였습니다."),
 
-    // Notice 관련
-    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NO4041", "해당 공지를 찾을 수 없습니다."),
+    // ALARM 관련
+    ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "AL4041", "해당 알람을 찾을 수 없습니다."),
+    FORBIDDEN_ALARM_ACCESS(HttpStatus.FORBIDDEN,"AL4031", "본인의 알림만 읽을 수 있습니다."),
+
 
 
     // JWT token

--- a/src/main/java/com/umc/hwaroak/service/AlarmService.java
+++ b/src/main/java/com/umc/hwaroak/service/AlarmService.java
@@ -26,4 +26,9 @@ public interface AlarmService {
      */
     List<AlarmResponseDto.InfoDto> getAllAlarmsForMember(Member member);
 
+    /**
+     *  알람 읽음 처리 하기
+     */
+    void markAsRead(Long alarmId, Member member);
+
 }

--- a/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
@@ -106,7 +106,7 @@ public class AlarmServiceImpl implements AlarmService {
                 .orElseThrow(() -> new GeneralException(ErrorCode.ALARM_NOT_FOUND));
 
         // alarm.getReceiver() != null -> 공지는 receiverId NULL이기 때문에 필수!
-        if (alarm.getReceiver() != null && !alarm.getReceiver().equals(member)) {
+        if (alarm.getReceiver() != null && !alarm.getReceiver().getId().equals(member.getId())) {
             throw new GeneralException(ErrorCode.FORBIDDEN_ALARM_ACCESS);
         }
 

--- a/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
@@ -77,9 +77,13 @@ public class AlarmServiceImpl implements AlarmService {
         alarmRepository.save(alarm);
     }
 
+    /**
+     * 알람함 최신순 전체 조회
+     * receiverId로 조회 or (receiverId=NULL && 공지)
+     */
     @Override
     public List<AlarmResponseDto.InfoDto> getAllAlarmsForMember(Member receiver) {
-        List<Alarm> alarms = alarmRepository.findAllByReceiverOrderByCreatedAtDesc(receiver);
+        List<Alarm> alarms = alarmRepository.findAllIncludingNotifications(receiver);
 
         return alarms.stream()
                 .map(alarm -> AlarmResponseDto.InfoDto.builder()
@@ -91,5 +95,6 @@ public class AlarmServiceImpl implements AlarmService {
                         .build())
                 .toList();
     }
+
 
 }


### PR DESCRIPTION
## 📌 Related Issue
- Closes #50 

---
## ✨ Summary (작업 개요)

알람 조회 기능 공지도 따로 처리해서 가져오게끔 수정
알람 읽음 처리 추가

---
## 🛠 Work Description (작업 상세)
알람 receiverId로 가져오되, 공지는 따로 receiverId=NULL로 생성되게끔 설계해서 NULL도 가져오게끔 했습니다.
알람 읽음 처리를 위해 엔티티에 isRead 추가했습니다

---
## ⚠️ Trouble Shooting (문제 해결)


---
## 🧪 Test Coverage
이렇게 읽기 전(isRead=false)인 알람(receiver=NULL)이 공지 하나, 친구요청(receiver=1) 하나 있습니다.
<img width="945" height="114" alt="image" src="https://github.com/user-attachments/assets/2cd89588-bc4b-47d4-80d7-bc423bde979d" />

전체 조회했을 때 receiverId=1(자기자신) 뿐만 아니라 NULL인 공지도 잘 읽어오고 있습니다.
<img width="1423" height="450" alt="image" src="https://github.com/user-attachments/assets/23e4cb2a-fd01-4a26-83c9-47828ade58cd" />

receiverId=1(로그인한 본인)인 요청과 공지도 읽어봤습니다.
<img width="1472" height="722" alt="image" src="https://github.com/user-attachments/assets/f1124d91-a372-4f5e-8b66-7bca7b9577ee" />

isRead = true 로 잘 바뀌네요~
<img width="942" height="129" alt="image" src="https://github.com/user-attachments/assets/371bf577-68ba-47e2-bcd0-b99cdc77de7d" />



---
## 😅 Uncompleted Tasks (미완료 작업)

생각해보니 공지는 누르면 공지페이지로 이동하고 또 거기에 공지 상세 조회가있는데, 상세 조회를 해야 읽음 처리가 되는게 맞다고 생각합니다
공지 읽음 처리 따로 빼기 -> 추후에 해보겠습니다


---
## 📢 To Reviewers


---
