### PR TITLE
[Fix] 알람 조회시 시 분 초 까지 반환되게끔 수정

### DIFF
--- a/src/main/java/com/umc/hwaroak/domain/common/BaseEntity.java
+++ b/src/main/java/com/umc/hwaroak/domain/common/BaseEntity.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -17,8 +18,8 @@ public abstract class BaseEntity {
 
     @CreatedDate
     @Column(updatable = false)
-    private LocalDate createdAt;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDate updatedAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/umc/hwaroak/dto/response/AlarmResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/response/AlarmResponseDto.java
@@ -1,5 +1,6 @@
 package com.umc.hwaroak.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.umc.hwaroak.domain.common.AlarmType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -7,7 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Schema(name = "알람 응답 DTO")
 public class AlarmResponseDto {
@@ -28,7 +29,7 @@ public class AlarmResponseDto {
         private String title;
 
         @Schema(description = "알람 생성일", example = "2025-07-14")
-        private LocalDate createdAt; // 프론트에서 언제 올라온 공지인지 정렬 및 표시용
+        private LocalDateTime createdAt; // 프론트에서 언제 올라온 공지인지 정렬 및 표시용
     }
 
     /**
@@ -53,6 +54,7 @@ public class AlarmResponseDto {
         private AlarmType alarmType;
 
         @Schema(description = "알람 생성일", example = "2025-07-14")
-        private LocalDate createdAt;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,4 +14,6 @@ spring:
     hibernate:
       ddl-auto: update
 
+  jackson:
+    time-zone: Asia/Seoul
 


### PR DESCRIPTION
## 📌 Related Issue
> 관련 이슈가 있다면 작성해주세요
- Closes #65 

---
## ✨ Summary (작업 개요)

알람 조회 시 시분초 까지 반환되게끔 수정했습니다

---
## 🛠 Work Description (작업 상세)

Jackson 라이브러리 이용해서 직렬화 했습니다.
BaseEntity의 created_At, updated_At를 LocalDate -> LocalDateTime으로 수정하였고, 이와 관련된 로직들 다 수정했습니다.

---
## ⚠️ Trouble Shooting (문제 해결)


---
## 🧪 Test Coverage
"2025-07-24 19:00:53" 형식으로 출력됩니다.
<img width="1413" height="346" alt="image" src="https://github.com/user-attachments/assets/baeeec05-1ae0-463b-b59f-f64a92eeb0f5" />



---
## 😅 Uncompleted Tasks (미완료 작업)


---
## 📢 To Reviewers

---
