### PR TITLE
refactor: 친구 요청시 단방향 관계만 체크하고 있던 문제 양방향 체크로 수정(#77)

### DIFF
--- a/src/main/java/com/umc/hwaroak/domain/Friend.java
+++ b/src/main/java/com/umc/hwaroak/domain/Friend.java
@@ -6,10 +6,12 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "friend")
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 기본 생성자
 public class Friend extends BaseEntity {
 


### PR DESCRIPTION
## 📌 Related Issue
> 관련 이슈가 있다면 작성해주세요
- Closes #77 

---
## ✨ Summary (작업 개요)
기존에 친구요청 시 단방향 체크만 하고 있었어서, 즉 A가 B에게 친구요청시 B가 친구수락후 친구삭제(A를 삭제)하면 receiverId에 대한 것만 BLOCKED 처리가 되버려서 B가 다시 친구요청을 하려면 이미 친구요청중이라고 떠버리는 오류가 있었습니다! -> 양방향 체크로 수정했습니다!

---
## 🛠 Work Description (작업 상세)
BLCOKED,REJECTED 상태일 때 반대 방향에서도 가능하게하게끔 setter로 receiverId랑 senderId를 바꾸어서 요청 보내게끔 수정하였습니다!


---
## 🧪 Test Coverage
해당 문제에 대해 유저 두명으로 확인했습니다!
<img width="276" height="430" alt="image" src="https://github.com/user-attachments/assets/760aaadc-6e84-47e6-beec-672a7a6803b5" />



---
## 😅 Uncompleted Tasks (미완료 작업)

---
## 📢 To Reviewers
---
