### PR TITLE
[refactor] 불씨 알림 SSE를 통해 전송하기

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -16,6 +16,8 @@ http {
 
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Connection 'keep-alive';
+            proxy_http_version 1.1;
         }
     }
 }

--- a/src/main/java/com/umc/hwaroak/converter/AlarmConverter.java
+++ b/src/main/java/com/umc/hwaroak/converter/AlarmConverter.java
@@ -12,6 +12,7 @@ public class AlarmConverter {
                 .alarmType(alarm.getAlarmType())
                 .title(alarm.getTitle())
                 .message(alarm.getMessage())
+                .createdAt(alarm.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/umc/hwaroak/repository/EmitterRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/EmitterRepository.java
@@ -14,9 +14,5 @@ public interface EmitterRepository {
 
     void remove(String key);
 
-    List<SseEmitter> getListByKeyPrefix(String keyPrefix);
-
-    List<String> getKeyListByKeyPrefix(String keyPrefix);
-
     Map<String, List<SseEmitter>> findAllEmittersStartWithByMemberId(String memberId);
 }

--- a/src/main/java/com/umc/hwaroak/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/com/umc/hwaroak/repository/EmitterRepositoryImpl.java
@@ -31,25 +31,11 @@ public class EmitterRepositoryImpl implements EmitterRepository {
         }
         return Optional.empty();
     }
-    // 전체 조회(Prefix이용)
-    @Override
-    public List<SseEmitter> getListByKeyPrefix(String keyPrefix) {
-        return emitters.entrySet().stream()
-                .filter(entry -> entry.getKey().startsWith(keyPrefix))
-                .flatMap(entry -> entry.getValue().stream())
-                .collect(Collectors.toList());
-    }
+
     // 삭제
     @Override
     public void remove(String key) {
         emitters.remove(key);
-    }
-    // key값들 전체 조회
-    @Override
-    public List<String> getKeyListByKeyPrefix(String keyPrefix) {
-        return emitters.keySet().stream()
-                .filter(key -> key.startsWith(keyPrefix))
-                .collect(Collectors.toList());
     }
 
     // MemberId 기반

--- a/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
@@ -134,9 +134,18 @@ public class AlarmServiceImpl implements AlarmService {
                 .receiver(receiver)
                 .alarmType(AlarmType.FIRE)
                 .title("불 키우기")
+                .message(nickname + "님께서 불씨를 지폈어요!")
                 .content(nickname + "님께서 불씨를 지폈어요!")
                 .build();
-        alarmRepository.save(alarm); // ✅ 이거 꼭 있어야 함!
+        alarmRepository.save(alarm);
+        TransactionSynchronizationManager.registerSynchronization(
+                new CustomTransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        redisPublisher.publish(alarm.getAlarmType().getValue(), AlarmConverter.toPreviewDto(alarm));
+                    }
+                }
+        );
     }
 
      /*  알람 읽기 api

--- a/src/main/java/com/umc/hwaroak/serviceImpl/EmitterServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/EmitterServiceImpl.java
@@ -11,7 +11,6 @@ import com.umc.hwaroak.service.EmitterService;
 import com.umc.hwaroak.util.SseRepositoryKeyGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -80,7 +79,6 @@ public class EmitterServiceImpl implements EmitterService {
         return memberId + "_" + eventName.getValue() + "_" + now;
     }
 
-    @Async
     @Override
     public void send(AlarmResponseDto.PreviewDto responseDto) {
 


### PR DESCRIPTION
## 📌 Related Issue
- Closes #80 

---
## ✨ Summary (작업 개요)
- 추가된 불씨 알림 API에 맞게 SSE 통한 알림 전송 구현

---
## 🛠 Work Description (작업 상세)
- 불씨 알림 API에 대하여 publish 코드 추가 및 SSE 통한 알림
- 불필요한 메서드 삭제 및 필드 누락 추가
- Nginx에서 Connection header에 대하여 추가( 응답 후에도 계속 클라이언트와의 연결 유지 )
```
proxy_set_header Connection 'keep-alive';
proxy_http_version 1.1;
```

---
## 🧪 Test Coverage
- 테스트 확인 ( 실시간 전송 )
<img width="550" height="299" alt="image" src="https://github.com/user-attachments/assets/6dd8bad3-1e6b-4074-b8ea-67fbfda52bf4" />
<img width="1136" height="542" alt="image" src="https://github.com/user-attachments/assets/85e5bae6-1c58-4913-b293-da3aa132ff6c" />


---
## 😅 Uncompleted Tasks (미완료 작업)
- SSE에 대한 만료 시간에 대한 관리 필요할 것 같습니다
- 비동기로 SSE 전송에 대한 별도의 스레드 작업을 하는 방향 찾아보기


---
