### PR TITLE
[Fix] Alarm 전체 조회시 InfoDto에 isRead(알람 읽음) 여부 반환값 추가

### DIFF
--- a/src/main/java/com/umc/hwaroak/dto/response/AlarmResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/response/AlarmResponseDto.java
@@ -64,6 +64,9 @@ public class AlarmResponseDto {
         @Schema(description = "알람 종류", example = "FRIEND_REQUEST")
         private AlarmType alarmType;
 
+        @Schema(description = "알람 읽음 여부, 공지는 관련 X", example = "true or false")
+        private Boolean isRead;
+
         @Schema(description = "알람 생성일", example = "2025-07-14")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime createdAt;

--- a/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
@@ -71,6 +71,7 @@ public class AlarmServiceImpl implements AlarmService {
                 .id(alarm.getId())
                 .title(alarm.getTitle())
                 .content(alarm.getContent())
+                .isRead(alarm.isRead())
                 .createdAt(alarm.getCreatedAt())
                 .build();
     }
@@ -117,6 +118,7 @@ public class AlarmServiceImpl implements AlarmService {
                         .title(alarm.getTitle())
                         .content(alarm.getContent())
                         .alarmType(alarm.getAlarmType())
+                        .isRead(alarm.isRead())
                         .createdAt(alarm.getCreatedAt())
                         .build())
                 .toList();


### PR DESCRIPTION
## 📌 Related Issue
- Closes #86 

---
## ✨ Summary (작업 개요)
알람 전체 조회시 알람 읽음 여부가 반환값에 빠져 있어서 프론트에서 처리하기 힘든 문제가 있었습니다.

---
## 🛠 Work Description (작업 상세)
InfoDto에 isRead 반환값 추가해주고 서비스로직에 매핑 로직 추가했습니다.

---
## 🧪 Test Coverage

스웨거로 잘 반환되는 것 확인했습니다!

