### PR TITLE
[feat] 메인화면의 화록이 아이템 클릭시 알맞는 멘트 반환 api

### DIFF
--- a/src/main/java/com/umc/hwaroak/controller/QuestionController.java
+++ b/src/main/java/com/umc/hwaroak/controller/QuestionController.java
@@ -37,4 +37,22 @@ public class QuestionController {
     public QuestionResponseDto getMainMessage() {
         return questionService.getMainMessage();
     }
+
+
+    @Operation(
+            summary = "아이템 클릭 시 메시지 조회",
+            description = """
+        사용자가 메인 화면에서 선택한 아이템을 클릭했을 때 보여줄 멘트를 반환합니다.<br><br>
+        디폴트 멘트 여러개와 아이템 종류별 멘트중에 랜덤으로 뜹니다.
+        """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "아이템 클릭 메시지 조회 성공",
+            content = @Content(schema = @Schema(implementation = QuestionResponseDto.class))
+    )
+    @GetMapping("/item-click")
+    public QuestionResponseDto getItemClickMessage() {
+        return questionService.getItemClickMessage();
+    }
 }

--- a/src/main/java/com/umc/hwaroak/repository/QuestionRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/QuestionRepository.java
@@ -1,6 +1,5 @@
 package com.umc.hwaroak.repository;
 
-import com.umc.hwaroak.domain.Member;
 import com.umc.hwaroak.domain.Question;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 

--- a/src/main/java/com/umc/hwaroak/response/ErrorCode.java
+++ b/src/main/java/com/umc/hwaroak/response/ErrorCode.java
@@ -75,6 +75,9 @@ public enum ErrorCode implements BaseCode{
     // Tag
     INVALID_TAG(HttpStatus.NOT_FOUND, "TAG4041", "해당 태그와 일치하는 멘트가 없습니다"),
 
+    // Question
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QES4041", "해당 멘트가 존재하지 않습니다"),
+
     // SERVER
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SE5001", "서버 내의 오류입니다."),
     ;

--- a/src/main/java/com/umc/hwaroak/service/QuestionService.java
+++ b/src/main/java/com/umc/hwaroak/service/QuestionService.java
@@ -4,4 +4,5 @@ import com.umc.hwaroak.dto.response.QuestionResponseDto;
 
 public interface QuestionService {
     QuestionResponseDto getMainMessage();
+    QuestionResponseDto getItemClickMessage();
 }


### PR DESCRIPTION
## 📌 Related Issue
- Closes #103 

---
## ✨ Summary (작업 개요)

화록이가 갖고 있는 아이템 누르면 알맞는 멘트 반환해주는 api 구현했습니다.

---
## 🛠 Work Description (작업 상세)

member_item의 isSecleted = true인 것이 화록이가 들고 있는 아이템이라고 생각하고 로직 구성했습니다.

기존에 있던 Question 엔티티의 tag기반 조회하는 방식 활용하였습니다. tag 종류별로 DB에 멘트들 추가하였습니다.

QuestionService에서 "tag = ITEM_DEFAULT"인 것들 랜덤으로 조회하고,  아이템별 고유 멘트 "tag = ITEM_(Level)"인 멘트 하나 가져와서 50퍼 확률로 뜨게끔 했습니다.

---
## 🧪 Test Coverage

화록이가 cup 들고 있다고 가정하고 테스트 중인데 컵과 맞는 멘트 잘뜨고

<img width="1437" height="242" alt="image" src="https://github.com/user-attachments/assets/8fd97ee1-ae1b-418a-9394-0f535548b298" />

기본 멘트들도 잘 뜹니다.

<img width="1379" height="231" alt="image" src="https://github.com/user-attachments/assets/072a68c3-06fb-4f7f-9914-58e42f63ddcd" />


---
## 📢 To Reviewers

SQL INSERT문 노션에 추가해뒀습니다!! 제가 배포서버에 미리 넣어놓겠습니다!!

@yc3697  저번 회의때 말씀해주신 월간리포트 관련 수정사항 PM님에게 여쭤보니 아래 내용과 같이 일기를 하나도 안썻을 시에도 리포트가 있어서 알림은 그냥 생성해도 괜찮다는데, 저희 한달내에 일기 하나도 안썻을시에 감정분석이 잘 되어있나요..? 그냥 0퍼로 뜨나..?
<img width="305" height="226" alt="image" src="https://github.com/user-attachments/assets/14829744-0de6-48e9-b68a-593d876c2303" />



---
