### PR TITLE
[fix] 전체 알람 조회시 userId 반환되게끔 추가

### DIFF
--- a/src/main/java/com/umc/hwaroak/controller/AlarmController.java
+++ b/src/main/java/com/umc/hwaroak/controller/AlarmController.java
@@ -23,7 +23,7 @@ public class AlarmController {
 
     private final AlarmService alarmService;
 
-    @Operation(summary = "알림함 전체 조회", description = "로그인한 사용자의 모든 알람을 최신순으로 조회합니다.")
+    @Operation(summary = "알림함 전체 조회", description = "로그인한 사용자의 모든 알람을 최신순으로 조회합니다. 친구, 불씨 알람의 userId말고는 빈 문자열 입니다.")
     @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공",
             content = @Content(array = @ArraySchema(schema = @Schema(implementation = AlarmResponseDto.InfoDto.class)),
                     examples = @ExampleObject(value = """

--- a/src/main/java/com/umc/hwaroak/dto/response/AlarmResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/response/AlarmResponseDto.java
@@ -55,6 +55,9 @@ public class AlarmResponseDto {
         @Schema(description = "알람 ID", example = "1")
         private Long id;
 
+        @Schema(description = "알람 관련 사용자 ID (FRIEND_REQUEST, FIRE만 해당)", example = "kakao_1234abcd")
+        private String userId;
+
         @Schema(description = "알람 제목", example = "친구 요청")
         private String title;
 

--- a/src/main/java/com/umc/hwaroak/repository/AlarmRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/AlarmRepository.java
@@ -25,13 +25,13 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
      * receiverId로 조회 or (receiverId=NULL && 공지)
      */
     @Query("""
-        SELECT a FROM Alarm a
-        WHERE a.receiver = :receiver
-           OR a.receiver IS NULL AND a.alarmType IN ('NOTIFICATION', 'DAILY')
-        ORDER BY a.createdAt DESC
-    """)
+    SELECT a FROM Alarm a
+    LEFT JOIN FETCH a.sender
+    WHERE a.receiver = :receiver
+       OR (a.receiver IS NULL AND a.alarmType IN ('NOTIFICATION', 'DAILY'))
+    ORDER BY a.createdAt DESC
+""")
     List<Alarm> findAllIncludingGlobalAlarms(@Param("receiver") Member receiver);
-
 
 
     // sender + receiver + alarmType 기준 최신 알람 (여러 개 가능)

--- a/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/AlarmServiceImpl.java
@@ -110,22 +110,32 @@ public class AlarmServiceImpl implements AlarmService {
      * 알람함 최신순 전체 조회
      * receiverId로 조회 or (receiverId=NULL && 공지)
      */
+    @Transactional(readOnly = true)
     @Override
     public List<AlarmResponseDto.InfoDto> getAllAlarmsForMember() {
         Member receiver = memberLoader.getMemberByContextHolder();
         List<Alarm> alarms = alarmRepository.findAllIncludingGlobalAlarms(receiver);
 
+        // sender가 존재하면 sender의 UserId 가져옵니다. 아니면 널~
         return alarms.stream()
-                .map(alarm -> AlarmResponseDto.InfoDto.builder()
-                        .id(alarm.getId())
-                        .title(alarm.getTitle())
-                        .content(alarm.getContent())
-                        .alarmType(alarm.getAlarmType())
-                        .isRead(alarm.isRead())
-                        .createdAt(alarm.getCreatedAt())
-                        .build())
+                .map(alarm -> {
+                    String userId = (alarm.getAlarmType() == AlarmType.FIRE || alarm.getAlarmType() == AlarmType.FRIEND_REQUEST)
+                            ? (alarm.getSender() != null ? alarm.getSender().getUserId() : null)
+                            : "";
+
+                    return AlarmResponseDto.InfoDto.builder()
+                            .id(alarm.getId())
+                            .title(alarm.getTitle())
+                            .content(alarm.getContent())
+                            .alarmType(alarm.getAlarmType())
+                            .isRead(alarm.isRead())
+                            .createdAt(alarm.getCreatedAt())
+                            .userId(userId)
+                            .build();
+                })
                 .toList();
     }
+
 
     /**
      *  불씨 보냈을시 알람 생성하기


### PR DESCRIPTION
## 📌 Related Issue
> 관련 이슈가 있다면 작성해주세요
- Closes #118 

---
## ✨ Summary (작업 개요)

전체 알람 조회시 불씨알람은 누르면 친구페이지로 이동합니다. 친구 관련 API는 다 member의 userId가 필요합니다. 근데 알람 관련 responseDTO에는 userId가 없었어서 반환 추가했습니다.

---
## 🛠 Work Description (작업 상세)

유수님이 불씨알람, 친구요청 알람만 userId 값 넣어주고 나머지 알람은 ""로 해달라고 하시길래 매핑 로직에서 ? : 써서 해당 조건 만족해서 매핑되게끔 했습니다. 


---
## ⚠️ Trouble Shooting (문제 해결)

서비스로직에 @Transactional(readonly = true) 이거 솔직히 왜 붙히는지 여태까지 안와닿았는데 이번에 좀 깨달았습니다.
Alarm 필드의 많은 연관관계 필드변수들이 LAZY하게 선언되어있는데, LAZY는 미리 가져오는 것이 아닌 DB에 "접근"하는 시점에 데이터를 가져오지 않습니까?! 

근데 저는 뭣도 모르고 그냥 빌더 문법을 이용한 매핑만 신경쓰고 있었는데 갑자기 LazyInitializationException 에러가 터지면서 500에러가 나는겁니다?!(요청 방식에 문제도 없는데?!?!)

기술 블로그 뒤적뒤적해보니 @Transactional(readonly = true)가 안붙혀져있으면, 세션이 이미 종료된 상태에서 LAZY하게 프록시 객체에 접근하면서 해당 오류가 발생한다고 합니다.  근데 해당 어노테이션은 스프링을 믿는 좀 불편한(?) 최소한의 조치이고, 
좀 더 찾아보니 fetch join으로 LAZY한 변수를 미리 로딩해놓는 방식을 DB에서 하는 안전한 조치이기에 현업에서 많이 쓴다고 하더군요.(복잡한 응답 구조를 만들어야해서 연관 객체 로딩 전략에 더욱 주의해야 할때) -> 저는 @Query로 해당 조치도 취해봤습니다.

근데 또 수정하고 나니 @Transactional(readonly = true) 남발하면 성능에 무리가 간다고도 하네요...


---
## 🧪 Test Coverage

userId 알람 종류별로 잘 뜨는거 확인했습니다.

<img width="1398" height="524" alt="image" src="https://github.com/user-attachments/assets/a19455f7-9158-4d33-a804-3b8c6b83786b" />



---
## 📢 To Reviewers

문제해결 내용은 저의 트러블슈팅 반찬이 되어서 공유해봅니다.

