### PR TITLE
[fix] 친구 페이지 방문시 친구의 아이템 id, 일기 감정들 반환추가

### DIFF
--- a/src/main/java/com/umc/hwaroak/controller/FriendController.java
+++ b/src/main/java/com/umc/hwaroak/controller/FriendController.java
@@ -5,6 +5,7 @@ import com.umc.hwaroak.dto.response.FriendResponseDto;
 import com.umc.hwaroak.service.FriendService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -86,9 +87,33 @@ public class FriendController {
         return friendService.fireFriend(userId);
     }
 
-    @Operation(summary = "친구 페이지 방문하기", description = "친구 페이지를 방문합니다.")
-    @ApiResponse(responseCode = "200", description = "친구 정보 조회 성공")
-    @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다")
+    @Operation(
+            summary = "친구 페이지 방문하기",
+            description = "친구 페이지를 방문하여 친구의 기본 정보, 최근 일기 기반 감정 분석, 감정 ENUM, 선택한 아이템 ID를 조회합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "친구 정보 조회 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = FriendResponseDto.FriendPageInfo.class),
+                    examples = @ExampleObject(
+                            value = """
+            {
+              "userId": "#@!3132",
+              "nickname": "화록이2",
+              "message": "화록이2님은 깔끼해요",
+              "emotions": "JOY,SADNESS",
+              "selectedItemId": 5
+            }
+            """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "해당 사용자를 찾을 수 없습니다"
+    )
     @GetMapping("/{userId}")
     public FriendResponseDto.FriendPageInfo getFriendPage(@PathVariable String userId) {
         return friendService.getFriendPage(userId);

--- a/src/main/java/com/umc/hwaroak/dto/response/FriendResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/response/FriendResponseDto.java
@@ -60,10 +60,18 @@ public class FriendResponseDto {
     public static class FriendPageInfo {
         @Schema(description = "친구의 userId", example = "#@!3132")
         private String userId;
+
         @Schema(description = "친구의 닉네임", example = "화록이2")
         private String nickname;
+
         @Schema(description = "친구의 그날 감정 분석", example = "화록이2님은 깔끼해요 or 불씨를 지펴보세요!")
         private String message;  // GPT 응답 or 디폴트 메시지
+
+        @Schema(description = "친구의 그날 감정 ENUM 리스트(없으면 빈 문자열)", example = "JOY,SADNESS")
+        private String emotions;
+
+        @Schema(description = "친구가 선택한 MemberItem의 PK", example = "5")
+        private Long selectedItemId;
     }
 
 }

--- a/src/main/java/com/umc/hwaroak/serviceImpl/FriendServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/FriendServiceImpl.java
@@ -4,6 +4,8 @@ import com.umc.hwaroak.authentication.MemberLoader;
 import com.umc.hwaroak.domain.Diary;
 import com.umc.hwaroak.domain.Friend;
 import com.umc.hwaroak.domain.Member;
+import com.umc.hwaroak.domain.MemberItem;
+import com.umc.hwaroak.domain.common.Emotion;
 import com.umc.hwaroak.domain.common.FriendStatus;
 import com.umc.hwaroak.dto.response.FireAlarmResponseDto;
 import com.umc.hwaroak.dto.response.FriendResponseDto;
@@ -270,23 +272,43 @@ public class FriendServiceImpl implements FriendService {
         Member friend = memberRepository.findByUserId(friendUserId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
 
-        // LocalDateTime → LocalDate
+        // 최근 3일 내 최신 일기 조회
         LocalDate threeDaysAgo = LocalDateTime.now().minusDays(3).toLocalDate();
-
-        // 날짜 기준으로 최신 다이어리 하나 조회
         Optional<Diary> diaryOpt = diaryRepository
                 .findTop1ByMemberAndRecordDateGreaterThanEqualOrderByRecordDateDesc(friend, threeDaysAgo);
 
+        // GPT 분석 멘트
         String message = diaryOpt
                 .map(diary -> openAiUtil.extractDiaryFeelingSummary(diary.getContent()))
                 .orElse("불씨를 지펴보세요!");
+
+        // 감정 ENUM → message 만든 일기에서 가져오기 (없으면 "")
+        String emotions = diaryOpt
+                .map(d -> {
+                    List<Emotion> list = d.getEmotionList();
+                    if (list == null || list.isEmpty()) return "";
+                    return list.stream()
+                            .map(Enum::name)
+                            .collect(Collectors.joining(","));
+                })
+                .orElse("");
+
+        // 선택된 MemberItem ID
+        Long selectedItemId = friend.getMemberItemList().stream()
+                .filter(MemberItem::getIsSelected)
+                .findFirst()
+                .map(mi -> mi.getItem().getId()) // Item의 PK -> 친구의 아이템이므로 굳이 memberItem의 PK를 반환 안해도 된다고 생각.
+                .orElse(null);
 
         return FriendResponseDto.FriendPageInfo.builder()
                 .userId(friend.getUserId())
                 .nickname(friend.getNickname())
                 .message(message)
+                .emotions(emotions)
+                .selectedItemId(selectedItemId)
                 .build();
     }
+
 
 
 


### PR DESCRIPTION
## 📌 Related Issue
> 관련 이슈가 있다면 작성해주세요
- Closes #124 

---
## ✨ Summary (작업 개요)

친구 페이지 방문시 친구의 아이템 (item 고유 PK) 일기 감정들 반환 추가 햇습니다.
전 친구 페이지는 필요없는 줄 알았는데 경기도 오산이었습니다.


---
## 🧪 Test Coverage

친구꺼도 잘 반환됩니다. 프론트 분이 얼른 잘 연동하셨으면 좋겟네요
<img width="1261" height="300" alt="image" src="https://github.com/user-attachments/assets/501bf9d2-9db2-4569-b507-e210144b8a30" />


