### PR TITLE
[feat] 친구 아이템 리스트 조회 api 추가 및 수정

### DIFF
--- a/src/main/java/com/umc/hwaroak/controller/FriendController.java
+++ b/src/main/java/com/umc/hwaroak/controller/FriendController.java
@@ -93,4 +93,12 @@ public class FriendController {
     public FriendResponseDto.FriendPageInfo getFriendPage(@PathVariable String userId) {
         return friendService.getFriendPage(userId);
     }
+
+    @Operation(summary = "친구 아이템 리스트 조회", description = "친구의 모든 아이템 PK 리스트와 선택된 아이템 PK를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "친구 아이템 조회 성공")
+    @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다")
+    @GetMapping("/{userId}/items")
+    public FriendResponseDto.FriendItemsInfo getFriendItems(@PathVariable String userId) {
+        return friendService.getFriendItems(userId);
+    }
 }

--- a/src/main/java/com/umc/hwaroak/controller/FriendController.java
+++ b/src/main/java/com/umc/hwaroak/controller/FriendController.java
@@ -57,7 +57,7 @@ public class FriendController {
     @Operation(summary = "받은 친구 요청 목록 조회", description = "아직 수락/거절되지 않은, 내가 받은 친구 요청 목록을 최신순으로 조회합니다.")
     @ApiResponse(responseCode = "200", description = "받은 친구 요청 목록 조회 성공")
     @GetMapping("/received")
-    public List<FriendResponseDto.ReceivedRequestInfo> getReceivedFriendRequests() {
+    public List<FriendResponseDto.FriendInfo> getReceivedFriendRequests() {
         return friendService.getReceivedFriendRequests();
     }
 
@@ -71,9 +71,9 @@ public class FriendController {
 
     @GetMapping("/search/{userId}")
     @Operation(summary = "userId로 회원 검색", description = "입력한 userId를 가진 회원을 검색합니다.")
-    @ApiResponse(responseCode = "200", description = "검색 성공", content = @Content(schema = @Schema(implementation = FriendResponseDto.SearchResultDto.class)))
+    @ApiResponse(responseCode = "200", description = "검색 성공", content = @Content(schema = @Schema(implementation = FriendResponseDto.FriendInfo.class)))
     @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음 (MEMBER_NOT_FOUND)")
-    public FriendResponseDto.SearchResultDto searchFriend(@PathVariable String userId) {
+    public FriendResponseDto.FriendInfo searchFriend(@PathVariable String userId) {
         return friendService.searchFriendByUserId(userId);
     }
 

--- a/src/main/java/com/umc/hwaroak/dto/response/FriendResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/response/FriendResponseDto.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 public class FriendResponseDto {
 
     /**
@@ -64,6 +66,17 @@ public class FriendResponseDto {
         private String nickname;
         @Schema(description = "친구의 그날 감정 분석", example = "화록이2님은 깔끼해요 or 불씨를 지펴보세요!")
         private String message;  // GPT 응답 or 디폴트 메시지
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class FriendItemsInfo {
+        @Schema(description = "친구의 아이템 PK 리스트", example = "[1, 2, 3, 5]")
+        private List<Long> items;
+
+        @Schema(description = "친구가 선택한 아이템의 PK", example = "3")
+        private Long selectedItem;
     }
 
 }

--- a/src/main/java/com/umc/hwaroak/dto/response/FriendResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/response/FriendResponseDto.java
@@ -16,15 +16,17 @@ public class FriendResponseDto {
     @Builder
     @AllArgsConstructor
     public static class FriendInfo {
-
-        @Schema(description = "친구의 UserId", example = "#@#12")
+        @Schema(description = "친구의 userId", example = "friend_123")
         private String userId;
 
-        @Schema(description = "친구 닉네임", example = "햇살가득이")
+        @Schema(description = "친구 닉네임", example = "화록이2")
         private String nickname;
 
-        @Schema(description = "친구 한줄소개", example = "오늘도 잘 부탁해요~")
+        @Schema(description = "친구 소개글", example = "안녕하세요! 화록 좋아요")
         private String introduction;
+
+        @Schema(description = "프로필 이미지 URL (없으면 null 또는 기본이미지 사용)", example = "https://.../profile.jpg")
+        private String profileImage;
     }
 
     @Getter

--- a/src/main/java/com/umc/hwaroak/dto/response/FriendResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/response/FriendResponseDto.java
@@ -32,35 +32,6 @@ public class FriendResponseDto {
     @Getter
     @Builder
     @AllArgsConstructor
-    public static class ReceivedRequestInfo {
-
-        @Schema(description = "받은 친구 요청의 UserId", example = "#@#12")
-        private String userId;
-
-        @Schema(description = "요청 보낸 사용자 닉네임", example = "감자소년")
-        private String nickname;
-
-        @Schema(description = "요청 보낸 사용자의 자기소개", example = "함께 친구해요 :)")
-        private String introduction;
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    public static class SearchResultDto {
-
-        @Schema(description = "찾은 유저의 UserId", example = "#!2231!")
-        private String userId;     // 유저 ID (공개용)
-        @Schema(description = "찾은 유저의 NickName", example = "나는야 화록이")
-        private String nickname;
-        @Schema(description = "찾은 유저의 자기소개", example = "안녕하세요~")
-        private String introduction;
-
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
     public static class FriendPageInfo {
         @Schema(description = "친구의 userId", example = "#@!3132")
         private String userId;

--- a/src/main/java/com/umc/hwaroak/service/FriendService.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendService.java
@@ -25,5 +25,7 @@ public interface FriendService {
 
     FriendResponseDto.FriendPageInfo getFriendPage(String friendUserId);
 
+    FriendResponseDto.FriendItemsInfo getFriendItems(String friendUserId);
+
     boolean isFriend(Member member1, Member member2);
 }

--- a/src/main/java/com/umc/hwaroak/service/FriendService.java
+++ b/src/main/java/com/umc/hwaroak/service/FriendService.java
@@ -15,11 +15,11 @@ public interface FriendService {
 
     List<FriendResponseDto.FriendInfo> getFriendList();
 
-    List<FriendResponseDto.ReceivedRequestInfo> getReceivedFriendRequests();
+    List<FriendResponseDto.FriendInfo> getReceivedFriendRequests();
 
     void deleteFriend(String friendMemberUserId);
 
-    FriendResponseDto.SearchResultDto searchFriendByUserId(String userId);
+    FriendResponseDto.FriendInfo searchFriendByUserId(String userId);
 
     FireAlarmResponseDto fireFriend(String friendUserId);
 

--- a/src/main/java/com/umc/hwaroak/serviceImpl/FriendServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/FriendServiceImpl.java
@@ -181,7 +181,7 @@ public class FriendServiceImpl implements FriendService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<FriendResponseDto.ReceivedRequestInfo> getReceivedFriendRequests() {
+    public List<FriendResponseDto.FriendInfo> getReceivedFriendRequests() {
         Member me = memberLoader.getMemberByContextHolder();
 
         List<Friend> requests = friendRepository.findAllByReceiverAndStatusOrderByCreatedAtDesc(
@@ -191,10 +191,11 @@ public class FriendServiceImpl implements FriendService {
         return requests.stream()
                 .map(friend -> {
                     Member sender = friend.getSender();
-                    return FriendResponseDto.ReceivedRequestInfo.builder()
+                    return FriendResponseDto.FriendInfo.builder()
                             .userId(sender.getUserId())
                             .nickname(sender.getNickname())
                             .introduction(sender.getIntroduction())
+                            .profileImage(sender.getProfileImage())
                             .build();
                 })
                 .collect(Collectors.toList());
@@ -222,7 +223,7 @@ public class FriendServiceImpl implements FriendService {
 
     @Override
     @Transactional(readOnly = true)
-    public FriendResponseDto.SearchResultDto searchFriendByUserId(String userId) {
+    public FriendResponseDto.FriendInfo searchFriendByUserId(String userId) {
         Member currentMember = memberLoader.getMemberByContextHolder();
 
         Member target = memberRepository.findByUserId(userId)
@@ -232,10 +233,11 @@ public class FriendServiceImpl implements FriendService {
             throw new GeneralException(ErrorCode.CANNOT_SEARCH_SELF);
         }
 
-        return FriendResponseDto.SearchResultDto.builder()
+        return FriendResponseDto.FriendInfo.builder()
                 .userId(target.getUserId())
                 .nickname(target.getNickname())
                 .introduction(target.getIntroduction())
+                .profileImage(target.getProfileImage())
                 .build();
     }
 

--- a/src/main/java/com/umc/hwaroak/serviceImpl/FriendServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/FriendServiceImpl.java
@@ -172,10 +172,12 @@ public class FriendServiceImpl implements FriendService {
                             .userId(friendMember.getUserId())
                             .nickname(friendMember.getNickname())
                             .introduction(friendMember.getIntroduction())
+                            .profileImage(friendMember.getProfileImage())
                             .build();
                 })
                 .collect(Collectors.toList());
     }
+
 
     @Override
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📌 Related Issue
> 관련 이슈가 있다면 작성해주세요
- Closes #128 

---
## ✨ Summary (작업 개요)

친구 아이템 리스트 조회 api 구현했습니다.
친구 조회 관련 api 반환값 profileImage url 추가했습니다. 그래야 친구칸이 알록달록 뜬다고 해서..

---
## 🛠 Work Description (작업 상세)

친구의 아이템은 싹다 item 고유 PK 입니다.

---
## 🧪 Test Coverage


아래와 같은 형식으로 친구의 memberItem 중 isReceived가 true인 것들의 item PK를 가져옵니다. selectedItem=true Item의 PK도 가져옵니다.
<img width="1412" height="334" alt="image" src="https://github.com/user-attachments/assets/91da9985-b39a-45ae-b512-a9c3b96f5222" />

친구 조회 DTO에 url 추가시키는 버전으로 통일했습니다.
<img width="1406" height="350" alt="image" src="https://github.com/user-attachments/assets/130d270b-59be-45c2-acc7-4cc2aaed02fd" />


---
## 📢 To Reviewers

하고나니 PR 단위가 너무 작은 것 같네요 다음엔 좀 더 늘리겠습니다.

---
