### PR TITLE
[fix] 친구 요청 알람 및 불 피우기 알람 수정

### DIFF
--- a/src/main/java/com/umc/hwaroak/serviceImpl/FriendServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/FriendServiceImpl.java
@@ -64,28 +64,24 @@ public class FriendServiceImpl implements FriendService {
     @Override
     @Transactional
     public void requestFriend(String receiverUserId) {
-        // [1] 현재 로그인된 유저
         Member sender = memberLoader.getMemberByContextHolder();
-
-        // [2] 수신자 조회
         Member receiver = memberRepository.findByUserId(receiverUserId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
 
-        // [3] 자기 자신에게 요청 금지
         if (sender.getId().equals(receiver.getId())) {
             throw new GeneralException(ErrorCode.CANNOT_ADD_SELF);
         }
 
-        // [4] 기존 관계 조회 (양방향)
         Optional<Friend> directOpt = friendRepository.findBySenderAndReceiver(sender, receiver);
         Optional<Friend> reverseOpt = friendRepository.findBySenderAndReceiver(receiver, sender);
 
-        // [4-1] 내가 보낸 기록이 있는 경우
+        // 내가 예전에 보낸 적 있음
         if (directOpt.isPresent()) {
             Friend f = directOpt.get();
             switch (f.getStatus()) {
-                case BLOCKED, REJECTED -> {
+                case BLOCKED, REJECTED  -> {
                     f.updateStatus(FriendStatus.REQUESTED); // 재요청 허용
+                    eventPublisher.publishEvent(new FriendRequestEvent(this, sender, receiver));
                     return;
                 }
                 case REQUESTED -> throw new GeneralException(ErrorCode.FRIEND_ALREADY_REQUESTED);
@@ -93,7 +89,7 @@ public class FriendServiceImpl implements FriendService {
             }
         }
 
-        // [4-2] 상대가 과거에 나에게 보낸 기록이 있는 경우
+        // 상대가 과거에 나에게 보낸 기록 있음
         if (reverseOpt.isPresent()) {
             Friend f = reverseOpt.get();
             switch (f.getStatus()) {
@@ -102,6 +98,7 @@ public class FriendServiceImpl implements FriendService {
                     f.setSender(sender);
                     f.setReceiver(receiver);
                     f.updateStatus(FriendStatus.REQUESTED);
+                    eventPublisher.publishEvent(new FriendRequestEvent(this, sender, receiver));
                     return;
                 }
                 case REQUESTED -> throw new GeneralException(ErrorCode.FRIEND_ALREADY_REQUESTED);
@@ -109,11 +106,12 @@ public class FriendServiceImpl implements FriendService {
             }
         }
 
-        // [5] 신규 요청 생성 + 알림
+        // 신규 생성
         Friend friend = new Friend(sender, receiver, FriendStatus.REQUESTED);
         friendRepository.save(friend);
         eventPublisher.publishEvent(new FriendRequestEvent(this, sender, receiver));
     }
+
 
 
 


### PR DESCRIPTION
## 📌 Related Issue
> 관련 이슈가 있다면 작성해주세요
- Closes #132 

---
## ✨ Summary (작업 개요)

1. 친구한테 불키우기를 누르면 친구요청이 전송됐다는 알림이 갑니다.
2. 한번 삭제 한 친구한테 친구요청 시 알림이 가지 않습니다.

두가지 오류가 있었습니다.

---
## 🛠 Work Description (작업 상세)

불 피우기 api시 friendrequestEvent로 되어있어서 친구 요청알람이 생기더라구요. fireEvent로 바꿨습니다.

친구 상태가 REJECTED, BLOCKED일때 다시 요청 가능하게끔 친구상태 갱신만 해주고, 알람 생성은 안하고 있었습니다. 
유연님이 만들어주신 Event 클래스 이용해서 간단하게 알람 생성도 추가했습니다! 확실히 이런 유틸 클래스가 확장성을 엄청 편리하게 해주네요!

```java
switch (f.getStatus()) {
                case BLOCKED, REJECTED  -> {
                    f.updateStatus(FriendStatus.REQUESTED); // 재요청 허용
                    eventPublisher.publishEvent(new FriendRequestEvent(this, sender, receiver));
                    return;
                }
                case REQUESTED -> throw new GeneralException(ErrorCode.FRIEND_ALREADY_REQUESTED);
                case ACCEPTED  -> throw new GeneralException(ErrorCode.FRIEND_ALREADY_FRIENDS);
            }
``` 

---
## 🧪 Test Coverage
> 어떤 테스트를 했고, 어떤 결과를 얻었는지 작성해주세요.

각 오류에 대해서 잘 되나 로컬에서 확인 완료했습니다.


