### PR TITLE
[fix] 복잡한 감정에 대한 메인 멘트 추가

### DIFF
--- a/src/main/java/com/umc/hwaroak/serviceImpl/QuestionServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/serviceImpl/QuestionServiceImpl.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 
 @RequiredArgsConstructor
 @Service
@@ -93,24 +94,44 @@ public class QuestionServiceImpl implements QuestionService {
         Optional<Diary> diaryOpt = diaryRepository.findByMemberIdAndRecordDate(member.getId(), LocalDate.now());
 
         if (diaryOpt.isEmpty()) {
-            log.warn("오늘 작성된 일기가 존재하지 않음 (예상 외)");
+            log.warn("오늘 작성된 일기가 존재하지 않음");
             return QuestionResponseDto.of("오늘 하루를 돌아보는 건 어때요?", "NONE");
         }
 
         List<Emotion> emotionList = diaryOpt.get().getEmotionList();
-        log.info("감정 리스트 추출 - size: {}", emotionList.size());
-
         if (emotionList == null || emotionList.isEmpty()) {
             log.warn("감정 리스트가 비어 있음 → 기본 멘트 반환");
             return QuestionResponseDto.of("당신의 하루가 궁금해요.", "NONE");
         }
 
-        Emotion selectedEmotion = emotionList.get(random.nextInt(emotionList.size()));
-        String tag = "EMOTION_" + selectedEmotion.name();
-        log.info("랜덤 감정 선택 완료 - emotion: {} → tag: {}", selectedEmotion.name(), tag);
+        // 긍정 / 부정 감정 세트 정의
+        Set<Emotion> POSITIVE_EMOTIONS = Set.of(
+                Emotion.CALM, Emotion.PROUD, Emotion.THANKFUL,
+                Emotion.HAPPY, Emotion.EXPECTED, Emotion.HEART_FLUTTER, Emotion.EXCITING
+        );
+        Set<Emotion> NEGATIVE_EMOTIONS = Set.of(
+                Emotion.BORED, Emotion.LONELY, Emotion.GLOOMY,
+                Emotion.SADNESS, Emotion.ANGRY, Emotion.ANNOYED, Emotion.STRESSFUL, Emotion.TIRED
+        );
 
+        boolean hasPositive = emotionList.stream().anyMatch(POSITIVE_EMOTIONS::contains);
+        boolean hasNegative = emotionList.stream().anyMatch(NEGATIVE_EMOTIONS::contains);
+
+        String tag;
+        if (hasPositive && hasNegative) {
+            // 혼합 감정 → EMOTION_DEFAULT
+            tag = "EMOTION_DEFAULT";
+            log.info("혼합 감정 감지 → tag: {}", tag);
+            return getRandomQuestionByTag(tag);
+        }
+
+        // 전부 긍정 또는 전부 부정 → 감정 하나 랜덤 선택 후 해당 태그에서 뽑기
+        Emotion selectedEmotion = emotionList.get(random.nextInt(emotionList.size()));
+        tag = "EMOTION_" + selectedEmotion.name();
+        log.info("단일 극성 감정 → selected: {} → tag: {}", selectedEmotion, tag);
         return getRandomQuestionByTag(tag);
     }
+
 
     // =======================
     // 내부 상태 판별 메서드


### PR DESCRIPTION
## 📌 Related Issue
> 관련 이슈가 있다면 작성해주세요
- Closes #138 

---
## ✨ Summary (작업 개요)

일기 감정에 대한 멘트를 화록이가 메인화면에서 반환중이었는데,   슬픈-행복한-짜증남 인데 랜덤으로 고르다 보니 행복하다는 식의 멘트를 뱉는 넌센스한 상황이 발생했습니다. 각 감정을 부정 긍정으로 나누어 PM님이 준비해주신 중립 멘트를 DEFAULT 멘트로 추가했습니다.

---
## 🛠 Work Description (작업 상세)

Set 자료구조를 이용했는데 String 맞는 거 있나 순환하는 구조라 좀 무식하게 비교하는 느낌이 들지만, O(3) 정도라 성능상으로 괜찮답니다!


---
## 🧪 Test Coverage

감정 복잡한 일기에 대해서는 DEFAULT 멘트가 뜹니다

<img width="1353" height="477" alt="image" src="https://github.com/user-attachments/assets/b70e7419-2cee-4afa-b2dd-317b7ceb5e4b" />


---
## 📢 To Reviewers

노션에 쿼리문 최신화 시켜놨습니다!!
서버엔 제가 추가해놓을게요!!

---
