### PR TITLE
[fix] 다음 보상 아이템으로 넘어가지 않는 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    runtimeOnly 'com.h2database:h2'
+
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/umc/hwaroak/controller/AuthController.java
+++ b/src/main/java/com/umc/hwaroak/controller/AuthController.java
@@ -5,7 +5,7 @@ import com.umc.hwaroak.dto.request.KakaoLoginRequestDto;
 import com.umc.hwaroak.dto.response.KakaoLoginResponseDto;
 import com.umc.hwaroak.response.ApiResponse;
 import com.umc.hwaroak.response.SuccessCode;
-import com.umc.hwaroak.serviceImpl.KakaoAuthServiceImpl;
+import com.umc.hwaroak.service.KakaoAuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final KakaoAuthServiceImpl kakaoAuthService;
+    private final KakaoAuthService kakaoAuthService;
 
     @PostMapping("/kakao")
     public ResponseEntity<ApiResponse<KakaoLoginResponseDto>> kakaoLogin(@RequestBody KakaoLoginRequestDto request) {

--- a/src/main/java/com/umc/hwaroak/domain/Alarm.java
+++ b/src/main/java/com/umc/hwaroak/domain/Alarm.java
@@ -43,11 +43,19 @@ public class Alarm extends BaseEntity {
     @Column(name = "content")
     private String content;
 
+    // 알림 전송 여부 추가
+    @Column(name = "sent", nullable = false)
+    private boolean sent = false;
+
     // 알림 읽었음 추가
     @Column(name = "is_read", nullable = false)
     private boolean isRead = false;
 
     public void markAsRead() {
         this.isRead = true;
+    }
+
+    public void markAsSent() {
+        this.sent = true;
     }
 }

--- a/src/main/java/com/umc/hwaroak/domain/Diary.java
+++ b/src/main/java/com/umc/hwaroak/domain/Diary.java
@@ -15,6 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Setter
 public class Diary extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/umc/hwaroak/domain/Item.java
+++ b/src/main/java/com/umc/hwaroak/domain/Item.java
@@ -3,6 +3,7 @@ package com.umc.hwaroak.domain;
 import com.umc.hwaroak.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class Item extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/hwaroak/domain/Member.java
+++ b/src/main/java/com/umc/hwaroak/domain/Member.java
@@ -1,6 +1,5 @@
 package com.umc.hwaroak.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.umc.hwaroak.domain.common.BaseEntity;
 import com.umc.hwaroak.domain.common.Role;
 import jakarta.persistence.*;
@@ -10,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Builder
 @Table(name = "member")
 @Getter
 @Setter

--- a/src/main/java/com/umc/hwaroak/event/listener/FireEventListener.java
+++ b/src/main/java/com/umc/hwaroak/event/listener/FireEventListener.java
@@ -1,43 +1,43 @@
-package com.umc.hwaroak.listener;
+package com.umc.hwaroak.event.listener;
 
 import com.umc.hwaroak.converter.AlarmConverter;
 import com.umc.hwaroak.domain.Alarm;
-import com.umc.hwaroak.domain.Member;
 import com.umc.hwaroak.domain.common.AlarmType;
-import com.umc.hwaroak.event.FriendRequestEvent;
+import com.umc.hwaroak.event.FireSendEvent;
 import com.umc.hwaroak.infrastructure.publisher.RedisPublisher;
 import com.umc.hwaroak.infrastructure.transaction.CustomTransactionSynchronization;
 import com.umc.hwaroak.repository.AlarmRepository;
-import com.umc.hwaroak.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-@RequiredArgsConstructor
 @Component
-public class FriendEventListener {
+@RequiredArgsConstructor
+public class FireEventListener{
 
     private final AlarmRepository alarmRepository;
     private final RedisPublisher redisPublisher;
 
     /**
-     *  친구 요청시 알람 생성하기
+     *  불씨 보냈을시 알람 생성하기
      */
-    @EventListener
-    @Transactional
-    public void sendFriendRequestAlarm(FriendRequestEvent event) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendFireAlarm(FireSendEvent event) {
+        String nickname = event.getSender().getNickname();
 
         Alarm alarm = Alarm.builder()
                 .sender(event.getSender())
                 .receiver(event.getReceiver())
-                .alarmType(AlarmType.FRIEND_REQUEST)
-                .title("친구 요청")
-                .message(event.getSender().getNickname() + "님이 친구 요청을 보냈습니다.")
-                .content(event.getSender().getNickname() + "님이 친구 요청을 보냈습니다.")
+                .alarmType(AlarmType.FIRE)
+                .title("불 키우기")
+                .message(nickname + "님께서 불씨를 지폈어요!")
+                .content(nickname + "님께서 불씨를 지폈어요!")
                 .build();
-
         alarmRepository.save(alarm);
         TransactionSynchronizationManager.registerSynchronization(
                 new CustomTransactionSynchronization() {

--- a/src/main/java/com/umc/hwaroak/event/listener/FriendEventListener.java
+++ b/src/main/java/com/umc/hwaroak/event/listener/FriendEventListener.java
@@ -1,41 +1,43 @@
-package com.umc.hwaroak.listener;
+package com.umc.hwaroak.event.listener;
 
 import com.umc.hwaroak.converter.AlarmConverter;
 import com.umc.hwaroak.domain.Alarm;
 import com.umc.hwaroak.domain.common.AlarmType;
-import com.umc.hwaroak.event.FireSendEvent;
+import com.umc.hwaroak.event.FriendRequestEvent;
 import com.umc.hwaroak.infrastructure.publisher.RedisPublisher;
 import com.umc.hwaroak.infrastructure.transaction.CustomTransactionSynchronization;
 import com.umc.hwaroak.repository.AlarmRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-@Component
 @RequiredArgsConstructor
-public class FireEventListener{
+@Component
+public class FriendEventListener {
 
     private final AlarmRepository alarmRepository;
     private final RedisPublisher redisPublisher;
 
     /**
-     *  불씨 보냈을시 알람 생성하기
+     *  친구 요청시 알람 생성하기
      */
-    @EventListener
-    @Transactional
-    public void sendFireAlarm(FireSendEvent event) {
-        String nickname = event.getSender().getNickname();
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendFriendRequestAlarm(FriendRequestEvent event) {
 
         Alarm alarm = Alarm.builder()
                 .sender(event.getSender())
                 .receiver(event.getReceiver())
-                .alarmType(AlarmType.FIRE)
-                .title("불 키우기")
-                .message(nickname + "님께서 불씨를 지폈어요!")
-                .content(nickname + "님께서 불씨를 지폈어요!")
+                .alarmType(AlarmType.FRIEND_REQUEST)
+                .title("친구 요청")
+                .message(event.getSender().getNickname() + "님이 친구 요청을 보냈습니다.")
+                .content(event.getSender().getNickname() + "님이 친구 요청을 보냈습니다.")
                 .build();
+
         alarmRepository.save(alarm);
         TransactionSynchronizationManager.registerSynchronization(
                 new CustomTransactionSynchronization() {

--- a/src/main/java/com/umc/hwaroak/event/listener/ItemEventListener.java
+++ b/src/main/java/com/umc/hwaroak/event/listener/ItemEventListener.java
@@ -1,4 +1,4 @@
-package com.umc.hwaroak.listener;
+package com.umc.hwaroak.event.listener;
 
 import com.umc.hwaroak.domain.Item;
 import com.umc.hwaroak.domain.Member;
@@ -12,9 +12,11 @@ import com.umc.hwaroak.repository.MemberRepository;
 import com.umc.hwaroak.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,8 +31,8 @@ public class ItemEventListener {
     private final MemberItemRepository memberItemRepository;
 
     // 수령 가능 아이템 추가하기
-    @EventListener
-    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void upgradeNextItem(ItemUpdateEvent event) {
 
         Member member = memberRepository.findById(event.getMemberId())
@@ -56,8 +58,8 @@ public class ItemEventListener {
     }
 
     // 삭제 시 이전으로 돌아가기
-    @EventListener
-    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void backToStatus(ItemRollbackEvent event) {
 
         Member member = memberRepository.findById(event.getMemberId())

--- a/src/main/java/com/umc/hwaroak/infrastructure/authentication/JwtTokenProvider.java
+++ b/src/main/java/com/umc/hwaroak/infrastructure/authentication/JwtTokenProvider.java
@@ -49,7 +49,7 @@ public class JwtTokenProvider {
     public String createAccessToken(Long memberId) {
         Role role = memberRepository.findById(memberId)
                 .map(Member::getRole)
-                .orElseThrow(() -> new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorCode.ROLE_NOT_FOUND));
 
         return createToken(memberId, role, accessTokenValidity, "ACCESS");
     }
@@ -57,7 +57,7 @@ public class JwtTokenProvider {
     public String createRefreshToken(Long memberId) {
         Role role = memberRepository.findById(memberId)
                 .map(Member::getRole)
-                .orElseThrow(() -> new GeneralException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorCode.ROLE_NOT_FOUND));
 
         return createToken(memberId, role, refreshTokenValidity, "REFRESH");
     }

--- a/src/main/java/com/umc/hwaroak/repository/ItemRepository.java
+++ b/src/main/java/com/umc/hwaroak/repository/ItemRepository.java
@@ -3,7 +3,6 @@ package com.umc.hwaroak.repository;
 import com.umc.hwaroak.domain.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {

--- a/src/main/java/com/umc/hwaroak/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/umc/hwaroak/repository/ItemRepositoryCustom.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 public interface ItemRepositoryCustom {
 
+    // 보상받지 않은 1개의 아이템
+    MemberItem getNotReceivedItem(Member member);
     // 아직 수령하지 않은 아이템 계산하기
     List<MemberItem> getAllNotReceivedItems(Member member);
     // 수령 받기

--- a/src/main/java/com/umc/hwaroak/response/ErrorCode.java
+++ b/src/main/java/com/umc/hwaroak/response/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode implements BaseCode{
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "접근 권한이 없습니다."),
     FAILED_KAKAO_PROFILE(HttpStatus.BAD_REQUEST, "KE4001", "카카오 서버로부터 프로필을 얻는 데에 실패하였습니다."),
     NOT_ENOUGH_INFO(HttpStatus.NOT_FOUND, "KE4002", "카카오로부터 얻은 정보가 충분하지 않습니다."),
+    ROLE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_003", "저장된 권한이 존재하지 않습니다."),
 
     // UID
     FAILED_UUID(HttpStatus.BAD_REQUEST, "UE4001", "UUID 생성에 실패하였습니다."),

--- a/src/main/java/com/umc/hwaroak/service/serviceImpl/AlarmServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/serviceImpl/AlarmServiceImpl.java
@@ -1,4 +1,4 @@
-package com.umc.hwaroak.serviceImpl;
+package com.umc.hwaroak.service.serviceImpl;
 
 import com.umc.hwaroak.infrastructure.authentication.MemberLoader;
 import com.umc.hwaroak.converter.AlarmConverter;

--- a/src/main/java/com/umc/hwaroak/service/serviceImpl/AlarmSettingServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/serviceImpl/AlarmSettingServiceImpl.java
@@ -1,4 +1,4 @@
-package com.umc.hwaroak.serviceImpl;
+package com.umc.hwaroak.service.serviceImpl;
 
 import com.umc.hwaroak.infrastructure.authentication.MemberLoader;
 import com.umc.hwaroak.domain.AlarmSetting;

--- a/src/main/java/com/umc/hwaroak/service/serviceImpl/DiaryServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/serviceImpl/DiaryServiceImpl.java
@@ -1,4 +1,4 @@
-package com.umc.hwaroak.serviceImpl;
+package com.umc.hwaroak.service.serviceImpl;
 
 import com.umc.hwaroak.event.ItemUpdateEvent;
 import com.umc.hwaroak.infrastructure.authentication.MemberLoader;
@@ -163,17 +163,18 @@ public class DiaryServiceImpl implements DiaryService {
                 .orElseThrow(() -> new GeneralException(ErrorCode.DIARY_NOT_FOUND));
 
         long diaryCnt = diaryRepository.countByMemberId(member.getId());
-        // member Reward 갱신
+        // member Reward 수정
         int reward = member.getReward();
-        if (reward == 7 && diaryCnt == 1) {
 
-        } else if (reward == 7) {
+        if (reward == 7) {
             // 이전의 아이템 상태로 돌아가기
             eventPublisher.publishEvent(new ItemRollbackEvent(this, member.getId()));
             member.setReward(1);
-        } else {
+        }
+        else {
             member.setReward(reward + 1);
         }
+
         memberRepository.save(member); // 변경사항 저장
         diaryRepository.delete(diary);
         emotionSummaryService.updateMonthlyEmotionSummary(diary.getRecordDate());  // 감정 통계 업데이트

--- a/src/main/java/com/umc/hwaroak/service/serviceImpl/EmitterServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/serviceImpl/EmitterServiceImpl.java
@@ -1,4 +1,4 @@
-package com.umc.hwaroak.serviceImpl;
+package com.umc.hwaroak.service.serviceImpl;
 
 import com.umc.hwaroak.infrastructure.authentication.MemberLoader;
 import com.umc.hwaroak.domain.common.AlarmType;

--- a/src/main/java/com/umc/hwaroak/service/serviceImpl/EmotionSummaryServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/serviceImpl/EmotionSummaryServiceImpl.java
@@ -1,4 +1,4 @@
-package com.umc.hwaroak.serviceImpl;
+package com.umc.hwaroak.service.serviceImpl;
 
 import com.umc.hwaroak.infrastructure.authentication.MemberLoader;
 import com.umc.hwaroak.domain.Diary;

--- a/src/main/java/com/umc/hwaroak/service/serviceImpl/FriendServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/serviceImpl/FriendServiceImpl.java
@@ -1,4 +1,4 @@
-package com.umc.hwaroak.serviceImpl;
+package com.umc.hwaroak.service.serviceImpl;
 
 import com.umc.hwaroak.event.FriendRequestEvent;
 import com.umc.hwaroak.infrastructure.authentication.MemberLoader;

--- a/src/main/java/com/umc/hwaroak/service/serviceImpl/ItemServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/serviceImpl/ItemServiceImpl.java
@@ -1,4 +1,4 @@
-package com.umc.hwaroak.serviceImpl;
+package com.umc.hwaroak.service.serviceImpl;
 
 import com.umc.hwaroak.infrastructure.authentication.MemberLoader;
 import com.umc.hwaroak.converter.ItemConverter;

--- a/src/main/java/com/umc/hwaroak/service/serviceImpl/KakaoAuthServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/serviceImpl/KakaoAuthServiceImpl.java
@@ -3,7 +3,7 @@
 //// 처음이면 회원가입 후 로그인 처리
 //// JWT 토큰과 유저 정보를 응답으로 반환
 
-package com.umc.hwaroak.serviceImpl;
+package com.umc.hwaroak.service.serviceImpl;
 
 import com.umc.hwaroak.domain.Item;
 import com.umc.hwaroak.domain.Member;

--- a/src/main/java/com/umc/hwaroak/service/serviceImpl/MemberServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/serviceImpl/MemberServiceImpl.java
@@ -1,4 +1,4 @@
-package com.umc.hwaroak.serviceImpl;
+package com.umc.hwaroak.service.serviceImpl;
 
 import com.umc.hwaroak.infrastructure.authentication.MemberLoader;
 import com.umc.hwaroak.converter.MemberConverter;

--- a/src/main/java/com/umc/hwaroak/service/serviceImpl/QuestionServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/serviceImpl/QuestionServiceImpl.java
@@ -1,4 +1,4 @@
-package com.umc.hwaroak.serviceImpl;
+package com.umc.hwaroak.service.serviceImpl;
 
 import com.umc.hwaroak.infrastructure.authentication.MemberLoader;
 import com.umc.hwaroak.domain.Diary;

--- a/src/main/java/com/umc/hwaroak/service/serviceImpl/S3ServiceImpl.java
+++ b/src/main/java/com/umc/hwaroak/service/serviceImpl/S3ServiceImpl.java
@@ -1,4 +1,4 @@
-package com.umc.hwaroak.serviceImpl;
+package com.umc.hwaroak.service.serviceImpl;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;


### PR DESCRIPTION
## 📌 Related Issue
- Closes #136 

---
## ✨ Summary (작업 개요)
- 일기 삭제 시 아이템 롤백이 제대로 작동되지 않는 것을 해결하였습니다
- 이벤트 발행에 대한 Transactional의 오류를 수정하였습니다
- 상위 패키지 구조가 너무 복잡하여 serviceImpl과 listenr 패키지를 하위로 이동시켰습니다

---
## 🛠 Work Description (작업 상세)
- 일기 삭제 시 Query문이 자세히 작성되지 않아서 이를 보충했습니다
```java
        if (target != null) {
            if (target.getIsSelected()) {
                // 대표 아이템을 휴지로 변경
                MemberItem baseItem = jpaQueryFactory
                        .selectFrom(memberItem)
                        .where(memberItem.member.eq(member)
                                .and(memberItem.item.level.eq(1)))
                        .fetchOne();
                baseItem.setIsSelected(true);
            }
            jpaQueryFactory.delete(memberItem)
                    .where(memberItem.id.eq(target.getId()))
                    .execute();
        } 
```


---
## ⚠️ Trouble Shooting (문제 해결)



---
## 🧪 Test Coverage
| 총 3개의 아이템 수령 받고, 2개 정도는 보상받기 클릭 안 한 상태 | 아이템 전부 보상받기로 DB까지 확인
|---|---|
|  <img width="621" height="153" alt="image" src="https://github.com/user-attachments/assets/b071a0b9-1ca2-4695-8282-5fa615590d97" />  |  <img width="702" height="684" alt="image" src="https://github.com/user-attachments/assets/d8eeae19-37e0-4699-b1b7-4cec7cd761f5" />  |
| 삭제해서 롤백 상태 실현 후 결과 확인 |  일기 작성 시 다음 보상이 다시 타이어가 된 것 확인 가능 |
|  <img width="415" height="80" alt="image" src="https://github.com/user-attachments/assets/d340dbbd-7d25-47ed-a838-963fe6144af3" /> |   <img width="860" height="500" alt="image" src="https://github.com/user-attachments/assets/7d1474a4-edee-4c6c-83ae-10f7be1012dd" />  |


---
## 😅 Uncompleted Tasks (미완료 작업)
- 쿼리문이 길어지다보니 삭제 시에 더 시간이 길어지고 있습니다.. 추후에 롤백에 대한 처리는 비동기로 변환하겠습니다
- 테스트 코드를 작성해보았는데 작성할 게 너무 많고 조정할 게 많아서 아예 다음 이슈 때 올리겠습니다,, 진작에 할 걸 그랬습니다!ㅜㅜ

---
## 📢 To Reviewers
- 테스트를 하기 위하여 테스트용 DB로 H2를 추가했습니다!
- ServiceImpl을 service 하위에 넣었습니다! 

---
