### PR TITLE
[fix] 보상 받을 수 있는 상황일 때 프론트 요청에따라 dto 수정

### DIFF
--- a/src/main/java/com/umc/hwaroak/dto/response/QuestionResponseDto.java
+++ b/src/main/java/com/umc/hwaroak/dto/response/QuestionResponseDto.java
@@ -1,11 +1,35 @@
 package com.umc.hwaroak.dto.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor(staticName = "of")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class QuestionResponseDto {
     private String content;
     private String tag;
+    private String itemInfo; // 추가
+    private String name;     // 추가
+
+    public static QuestionResponseDto of(String content, String tag) {
+        return QuestionResponseDto.builder()
+                .content(content)
+                .tag(tag)
+                .itemInfo("")
+                .name("")
+                .build();
+    }
+
+    public static QuestionResponseDto ofReward(String content, String tag, String itemInfo, String name) {
+        return QuestionResponseDto.builder()
+                .content(content)
+                .tag(tag)
+                .itemInfo(itemInfo)
+                .name(name)
+                .build();
+    }
 }


### PR DESCRIPTION
## 📌 Related Issue
> 관련 이슈가 있다면 작성해주세요
- Closes #145 

---
## ✨ Summary (작업 개요)

프론트에서 보상 받을 수 있는 여부를 보는 /question api 시 dto에 아이템 이름의 특정형식과 아이템 이름을 반환해달라고 요청이 왔습니다.

---
## 🛠 Work Description (작업 상세)

보상을 받을 수 있는 tag == REWARD일 시에만 요청 형식으로 문자열을 반환해줍니다.  아닐시엔 빈 문자열 입니다.

일기 쓰기만 하고 안받는 상황을 대비하여 member_item중 item_id가 가장 작은 아이템을 반환해주는 느낌으로 갔습니다.



---
## 🧪 Test Coverage

평상시엔 아래와 같이 빈 문자열 반환
<img width="2810" height="540" alt="image" src="https://github.com/user-attachments/assets/09e1e094-c01c-40db-8ea1-92236855db08" />

보상을 받을 수 있는 상황일때는 member_item중 item_id가 가장 작은 아이템을 프론트 요청 형식처럼 반환합니다.
<img width="2814" height="578" alt="image" src="https://github.com/user-attachments/assets/bd2607f5-090f-49c5-9559-cc5bc677b209" />

