### PR TITLE
[feat] Log 별도 관리하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 .env
 
 test
+
+logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       - "8080:8080"
     env_file:
       - .env
+    volumes:
+      - /home/ubuntu/logs:/app/logs
     depends_on:
       - redis
     networks:
@@ -17,6 +19,8 @@ services:
       - "8081:8080"
     env_file:
       - .env
+    volumes:
+      - /home/ubuntu/logs:/app/logs
     depends_on:
       - redis
     networks:

--- a/src/main/java/com/umc/hwaroak/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/hwaroak/exception/GlobalExceptionHandler.java
@@ -51,6 +51,9 @@ public class GlobalExceptionHandler {
     private void logError(Exception e, HttpServletRequest request) {
         log.error("Request URI : [{}] {}", request.getMethod(), request.getRequestURI());
         log.error("Exception : ", e);
+
+        log.error("Exception Type : {}", e.getClass().getName());
+        log.error("Exception Message : {}", e.getMessage());
     }
 
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -45,3 +45,10 @@ app:
     key-prefix: profiles             # 프로필 이미지 경로 prefix
     presign-ttl-seconds: 600         # Presigned URL 유효 시간 (초)
     allowed-content-types: image/jpeg,image/png,image/webp
+    
+logging:
+  level:
+    root: INFO
+  file:
+    path: ./logs
+  config: classpath:logback-spring.xml

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -44,3 +44,6 @@ app:
     presign-ttl-seconds: 600         # Presigned URL 유효 시간 (초)
     allowed-content-types: image/jpeg,image/png,image/webp
 
+logging:
+  level:
+    root: INFO

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,10 @@ spring:
   application:
     name: hwarok
 
+  output:
+    ansi:
+      enabled: always
+
   profiles:
     group:
       local: "local"

--- a/src/main/resources/logback-dev.yaml
+++ b/src/main/resources/logback-dev.yaml
@@ -1,0 +1,3 @@
+log.config.level=INFO
+
+log.config.path=./logs

--- a/src/main/resources/logback-local.yaml
+++ b/src/main/resources/logback-local.yaml
@@ -1,0 +1,3 @@
+log.config.level=INFO
+  
+log.config.path=./logs

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,14 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration>
+<configuration scan="true" scanPeriod="10 seconds">
+
+    <!-- Activate Spring Profile -->
+    <springProfile name = "local">
+        <property resource = "logback-local.yaml"/>
+    </springProfile>
+
+    <springProfile name = "dev">
+        <property resource = "logback-dev.yaml"/>
+    </springProfile>
 
     <!-- 변수값 설정 -->
-    <property name="LOGS_PATH" value="./logs"/>
-    <property name="LOGS_LEVEL" value="INFO" />
+    <property name = "LOG_LEVEL" value = "${log.config.level}"/>
+    <property name = "LOG_PATH" value = "${log.config.path}"/>
+    <!-- 로그 파일 패턴 -->
+    <property name ="LOG_PATTERN" value = "%-5level %d{yyyy-MM-dd HH:mm:ss}[%thread] [%logger{0}:%line] - %msg%n"/>
 
     <!-- Console Appender STDOUT -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm} %green(%-5level) %logger{36} - %msg %n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %green(%-5level) %highlight(%logger{36}) - %msg%n</pattern>
             <charset>UTF-8</charset>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
@@ -18,9 +29,9 @@
 
     <!-- Console Appender STDERR -->
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
-        <target>System.err</target>
+        <!--<target>System.err</target>-->
         <encoder>
-            <pattern>%d{HH:mm} %red(%-5level) %logger{36} - %msg %n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %red(%-5level) %highlight(%logger{36}) - %msg%n</pattern>
             <charset>UTF-8</charset>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
@@ -28,52 +39,48 @@
         </filter>
     </appender>
 
-    <!-- local 프로필: 콘솔만 참조 -->
-    <springProfile name="local">
-        <root level="${LOGS_LEVEL}">
-            <appender-ref ref="STDOUT"/>
-            <appender-ref ref="STDERR"/>
-        </root>
-    </springProfile>
-
     <!-- dev 프로필에서만 파일 Appender들을 정의 + 참조 -->
-    <springProfile name="dev">
-        <!-- File Appender -->
-        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>${LOGS_PATH}/log_file.log</file>
-            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                <fileNamePattern>${LOGS_PATH}/%d{yyyy-MM-dd}_%i.log</fileNamePattern>
-                <maxHistory>30</maxHistory>
-                <maxFileSize>10MB</maxFileSize>
-                <totalSizeCap>5GB</totalSizeCap>
-            </rollingPolicy>
-            <encoder>
-                <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
-                <charset>UTF-8</charset>
-            </encoder>
-        </appender>
+    <!-- File Appender -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/log_file.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <maxFileSize>10MB</maxFileSize>
+            <totalSizeCap>5GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
 
-        <!-- Error Appender -->
-        <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <!-- 파일 명과 경로 설정 -->
-            <file>${LOGS_PATH}/error_file.log</file>
-            <!-- Rolling 정책 -->
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>${LOGS_PATH}/%d{yyyy-MM-dd}_error.log</fileNamePattern>
-                <charset>UTF-8</charset>
-                <maxHistory>30</maxHistory>
-            </rollingPolicy>
-            <!-- 출력 패턴 설정 -->
-            <encoder>
-                <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
-                <charset>UTF-8</charset>
-            </encoder>
-            <!-- thredshold filter 넣어서 error 이상의 로그만 필터링 -->
-            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                <level>ERROR</level>
-            </filter>
-        </appender>
+    <!-- Error Appender -->
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- 파일 명과 경로 설정 -->
+        <file>${LOG_PATH}/error_file.log</file>
+        <!-- Rolling 정책 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/%d{yyyy-MM-dd}_error.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <!-- 출력 패턴 설정 -->
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+        <!-- thredshold filter 넣어서 error 이상의 로그만 필터링 -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
 
-    </springProfile>
+
+    <root level = "${LOG_LEVEL}">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="STDERR"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="ERROR_FILE"/>
+    </root>
 
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- 변수값 설정 -->
+    <property name="LOGS_PATH" value="./logs"/>
+    <property name="LOGS_LEVEL" value="INFO" />
+
+    <!-- Console Appender STDOUT -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+        <!-- 필요하면 INFO 이상으로 제한: ERROR도 포함됨 -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+    </appender>
+
+    <!-- Console Appender STDERR -->
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+
+    <!-- File Appender -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- 파일 명과 경로 설정 -->
+        <file>${LOGS_PATH}/log_file.log</file>
+        <!-- Rolling 정책 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOGS_PATH}/%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <!-- FILE 당 최고 용량 -->
+            <maxFileSize>10MB</maxFileSize>
+        </rollingPolicy>
+        <!-- 출력 패턴 설정 -->
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>5GB</totalSizeCap>
+        </encoder>
+    </appender>
+
+    <!-- Error Appender -->
+    <appender name="Error" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- 파일 명과 경로 설정 -->
+        <file>${LOGS_PATH}/error_file.log</file>
+        <!-- Rolling 정책 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOGS_PATH}/%d{yyyy-MM-dd}_error.log</fileNamePattern>
+            <charset>UTF-8</charset>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <!-- 출력 패턴 설정 -->
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+        <!-- thredshold filter 넣어서 error 이상의 로그만 필터링 -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <root level="${LOGS_LEVEL:-INFO}">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="STDERR"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="Error"/>
+    </root>
+
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,10 +8,9 @@
     <!-- Console Appender STDOUT -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm} %green(%-5level) %logger{36} - %msg %n</pattern>
             <charset>UTF-8</charset>
         </encoder>
-        <!-- 필요하면 INFO 이상으로 제한: ERROR도 포함됨 -->
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>INFO</level>
         </filter>
@@ -21,7 +20,7 @@
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm} %red(%-5level) %logger{36} - %msg %n</pattern>
             <charset>UTF-8</charset>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
@@ -29,53 +28,52 @@
         </filter>
     </appender>
 
+    <!-- local 프로필: 콘솔만 참조 -->
+    <springProfile name="local">
+        <root level="${LOGS_LEVEL}">
+            <appender-ref ref="STDOUT"/>
+            <appender-ref ref="STDERR"/>
+        </root>
+    </springProfile>
 
-    <!-- File Appender -->
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <!-- 파일 명과 경로 설정 -->
-        <file>${LOGS_PATH}/log_file.log</file>
-        <!-- Rolling 정책 -->
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOGS_PATH}/%d{yyyy-MM-dd}_%i.log</fileNamePattern>
-            <maxHistory>30</maxHistory>
-            <!-- FILE 당 최고 용량 -->
-            <maxFileSize>10MB</maxFileSize>
-        </rollingPolicy>
-        <!-- 출력 패턴 설정 -->
-        <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
-            <charset>UTF-8</charset>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>5GB</totalSizeCap>
-        </encoder>
-    </appender>
+    <!-- dev 프로필에서만 파일 Appender들을 정의 + 참조 -->
+    <springProfile name="dev">
+        <!-- File Appender -->
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOGS_PATH}/log_file.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${LOGS_PATH}/%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+                <maxHistory>30</maxHistory>
+                <maxFileSize>10MB</maxFileSize>
+                <totalSizeCap>5GB</totalSizeCap>
+            </rollingPolicy>
+            <encoder>
+                <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
+                <charset>UTF-8</charset>
+            </encoder>
+        </appender>
 
-    <!-- Error Appender -->
-    <appender name="Error" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <!-- 파일 명과 경로 설정 -->
-        <file>${LOGS_PATH}/error_file.log</file>
-        <!-- Rolling 정책 -->
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOGS_PATH}/%d{yyyy-MM-dd}_error.log</fileNamePattern>
-            <charset>UTF-8</charset>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-        <!-- 출력 패턴 설정 -->
-        <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-        <!-- thredshold filter 넣어서 error 이상의 로그만 필터링 -->
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>ERROR</level>
-        </filter>
-    </appender>
+        <!-- Error Appender -->
+        <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <!-- 파일 명과 경로 설정 -->
+            <file>${LOGS_PATH}/error_file.log</file>
+            <!-- Rolling 정책 -->
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOGS_PATH}/%d{yyyy-MM-dd}_error.log</fileNamePattern>
+                <charset>UTF-8</charset>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <!-- 출력 패턴 설정 -->
+            <encoder>
+                <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
+                <charset>UTF-8</charset>
+            </encoder>
+            <!-- thredshold filter 넣어서 error 이상의 로그만 필터링 -->
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+        </appender>
 
-    <root level="${LOGS_LEVEL:-INFO}">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="STDERR"/>
-        <appender-ref ref="FILE"/>
-        <appender-ref ref="Error"/>
-    </root>
+    </springProfile>
 
 </configuration>


### PR DESCRIPTION
## 📌 Related Issue
- Closes #144  

---
## ✨ Summary (작업 개요)
- logback 라이브러리를 통해 로그 파일을 따로 생성하였습니다

---
## 🛠 Work Description (작업 상세)
- 서버에 찍히는 콘솔이 계속 생성되는 것에 디버깅이 힘들어져 error에 대한 파일 따로 작성과, 모든 콘솔에 찍히는 대상들을 따로 저장하도록 하였습니다
```java
<pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}:%-3relative][%thread] %green(%-5level) %highlight(%logger{36}) - %msg%n</pattern>
```

---
## 🧪 Test Coverage
- 레벨 Debug로 설정해서 테스트
<img width="1379" height="670" alt="image" src="https://github.com/user-attachments/assets/341b6d36-8b6e-4d99-a9ac-277efb379c44" />

- logs 파일 생성 확인
<img width="320" height="121" alt="image" src="https://github.com/user-attachments/assets/163c5a7f-936b-4197-9817-5d5ffb965e21" />

- error_file 출력 확인
<img width="1182" height="710" alt="image" src="https://github.com/user-attachments/assets/6d8648c2-3bbe-4114-9c0f-a46f30c13f5d" />


---
## 😅 Uncompleted Tasks (미완료 작업)
- 로컬과 서버 환경을 분리해 로컬에서는 콘솔에 잘 찍히고 파일을 추가하지 않고, 서버 환경에서는 콘솔에서 안 찍히되 파일에만 저장하는 식으로 분리하려고 했는데 아직 못했습니다... 그래도 일단 프로필 분리는 해뒀습니다!ㅜㅜ

---
## 📢 To Reviewers
- 제가 프로필 분리를 아직 못해서 일단 콘솔이 정의한 패턴대로 나올 것 같은데 최대한 저희 기존 콘솔과 비슷하게 설정했습니다,,
<img width="1259" height="184" alt="image" src="https://github.com/user-attachments/assets/7f4b9e66-b5e6-4fb8-8360-a3f6756e1d3f" />


---
