### PR TITLE
[feat] https 발급

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,8 @@ jobs:
     steps:
       - name: SSH into EC2 server and Deploy
         uses: appleboy/ssh-action@v1
+        env:
+          SERVER_DNS : ${{ secrets.SERVER_DNS }}
         with:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,14 +43,27 @@ services:
     container_name: nginx
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - /home/ubuntu/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - home/ubuntu/certbot/conf:/etc/letsencrypt
+      - home/ubuntu/certbot/www:/var/certbot
     depends_on:
       - app-blue
       - app-green
     networks:
       - my-network
     restart: always
+
+  certbot:
+    image: certbot/certbot
+    container_name: certbot
+    volumes:
+      - home/ubuntu/certbot/conf:/etc/letsencrypt
+      - home/ubuntu/certbot/www:/var/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    networks:
+      - my-network
 
 volumes:
   redis_data:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,7 +7,7 @@ http {
 
     server {
         listen 80;
-        server_name hwaroak;
+        server_name ${SERVER_DNS};
 
         location / {
             proxy_pass http://backend;

--- a/src/main/java/com/umc/hwaroak/config/SwaggerConfig.java
+++ b/src/main/java/com/umc/hwaroak/config/SwaggerConfig.java
@@ -5,11 +5,18 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
+
 @Configuration
 public class SwaggerConfig {
+
+    @Value("${swagger.server-url}")
+    private String serverUrl;
 
     // 공통 OpenAPI - 관리자와 사용자 모두 볼 수 있음
     @Bean
@@ -26,7 +33,8 @@ public class SwaggerConfig {
                 .components(
                         new Components().addSecuritySchemes(securitySchemeName,
                                 new SecurityScheme().name(securitySchemeName).type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")))
-                .info(info);
+                .info(info)
+                .servers(List.of(new Server().url(serverUrl)));
     }
 
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -52,3 +52,6 @@ logging:
   file:
     path: ./logs
   config: classpath:logback-spring.xml
+
+swagger:
+  server-url: ${DEV_BASE_URL}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -47,3 +47,6 @@ app:
 logging:
   level:
     root: INFO
+
+swagger:
+  server-url: ${LOCAL_BASE_URL}


### PR DESCRIPTION
## 📌 Related Issue
- Closes #151 

---
## ✨ Summary (작업 개요)
- https 발급을 위하여 docker compose에 certbot을 추가하였습니다

---
## 🛠 Work Description (작업 상세)
- nginx.conf에 백엔드 도메인 주소가 들어가도록 변경
- certbot과 nginx docker volume 공유하도록 설정
- swagger에 https 요청을 제대로 받기 위한 URL 추가


---
